### PR TITLE
Patch to allow xsv to compile on windows-msvc compiler

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -10,6 +10,16 @@ use rustc_serialize::Decodable;
 use CliResult;
 use config::{Config, Delimiter};
 
+#[cfg(windows)]
+pub fn num_cpus() -> usize {
+    unsafe {
+        let mut sysinfo = ::std::mem::zeroed();
+        ::libc::GetSystemInfo(&mut sysinfo);
+        sysinfo.dwNumberOfProcessors as usize
+    }
+}
+
+#[cfg(unix)]
 pub fn num_cpus() -> usize {
     unsafe {
         return rust_get_num_cpus() as usize;


### PR DESCRIPTION
It appears that `rust_get_num_cpus()` is undefined on Windows. Adding this patch allows xsv to compile on Windows. However, it might be worth using https://crates.io/crates/num_cpus instead.

(Note: Rust does the same thing for one of its tests: https://github.com/rust-lang/rust/blob/8d86d1a4e17239361ecebced0d5dd246efa95512/src/libtest/lib.rs#L884-L897)