### PR TITLE
fix a few warnings from rustc+clippy

### DIFF
--- a/src/cmd/cat.rs
+++ b/src/cmd/cat.rs
@@ -95,7 +95,7 @@ impl Args {
         // Find the lengths of each record. If a length varies, then an error
         // will occur so we can rely on the first length being the correct one.
         let mut lengths = vec!();
-        for rdr in rdrs.iter_mut() {
+        for rdr in &mut rdrs {
             lengths.push(try!(rdr.byte_headers()).len());
         }
 

--- a/src/cmd/index.rs
+++ b/src/cmd/index.rs
@@ -53,6 +53,6 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
                          .delimiter(args.flag_delimiter);
     let rdr = try!(rconfig.reader_file());
     let idx = io::BufWriter::new(try!(fs::File::create(&pidx)));
-    let _ = try!(csv::index::create_index(rdr, idx));
+    try!(csv::index::create_index(rdr, idx));
     Ok(())
 }

--- a/src/cmd/stats.rs
+++ b/src/cmd/stats.rs
@@ -148,7 +148,7 @@ impl Args {
             });
         }
         drop(send);
-        Ok((headers, merge_all(recv.iter()).unwrap_or(vec![])))
+        Ok((headers, merge_all(recv.iter()).unwrap_or_else(Vec::new)))
     }
 
     fn stats_to_records(&self, stats: Vec<Stats>) -> Vec<Vec<String>> {
@@ -216,7 +216,7 @@ impl Args {
         if self.flag_median || all { fields.push("median"); }
         if self.flag_mode || all { fields.push("mode"); }
         if self.flag_cardinality || all { fields.push("cardinality"); }
-        fields.into_iter().map(|s| s.to_string()).collect()
+        fields.into_iter().map(|s| s.to_owned()).collect()
     }
 }
 
@@ -296,7 +296,7 @@ impl Stats {
     fn to_record(&mut self) -> Vec<String> {
         let typ = self.typ;
         let mut pieces = vec![];
-        let empty = || "".to_string();
+        let empty = || "".to_owned();
 
         pieces.push(self.typ.to_string());
         match self.minmax.as_ref().and_then(|mm| mm.show(typ)) {
@@ -342,7 +342,7 @@ impl Stats {
                         String::from_utf8_lossy(&*s).into_owned()
                     };
                     pieces.push(
-                        v.mode().map(lossy).unwrap_or("N/A".to_owned()));
+                        v.mode().map_or("N/A".to_owned(), lossy));
                 }
                 if self.which.cardinality {
                     pieces.push(v.cardinality().to_string());

--- a/src/config.rs
+++ b/src/config.rs
@@ -70,7 +70,7 @@ impl Config {
             Some(ref s) => {
                 let path = PathBuf::from(s);
                 let delim =
-                    if path.extension().map(|v| v == "tsv").unwrap_or(false) {
+                    if path.extension().map_or(false, |v| v == "tsv") {
                         b'\t'
                     } else {
                         b','
@@ -127,7 +127,7 @@ impl Config {
                     -> Result<Selection, String> {
         match self.select_columns {
             None => Err("Config has no 'SelectColums'. Did you call \
-                         Config::select?".to_string()),
+                         Config::select?".to_owned()),
             Some(ref sel) => sel.selection(first_record, !self.no_headers),
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -161,7 +161,7 @@ enum Command {
 
 impl Command {
     fn run(self) -> CliResult<()> {
-        let argv: Vec<_> = env::args().map(|v| v.to_string()).collect();
+        let argv: Vec<_> = env::args().map(|v| v.to_owned()).collect();
         let argv: Vec<_> = argv.iter().map(|s| &**s).collect();
         let argv = &*argv;
         match self {

--- a/src/util.rs
+++ b/src/util.rs
@@ -24,7 +24,7 @@ pub fn version() -> String {
     match (maj, min, pat) {
         (Some(maj), Some(min), Some(pat)) =>
             format!("{}.{}.{}", maj, min, pat),
-        _ => "".to_string(),
+        _ => "".to_owned(),
     }
 }
 
@@ -41,7 +41,7 @@ pub fn many_configs(inps: &[String], delim: Option<Delimiter>,
                     no_headers: bool) -> Result<Vec<Config>, String> {
     let mut inps = inps.to_vec();
     if inps.is_empty() {
-        inps.push("-".to_string()); // stdin
+        inps.push("-".to_owned()); // stdin
     }
     let confs = inps.into_iter()
                     .map(|p| Config::new(&Some(p))
@@ -55,7 +55,7 @@ pub fn many_configs(inps: &[String], delim: Option<Delimiter>,
 pub fn errif_greater_one_stdin(inps: &[Config]) -> Result<(), String> {
     let nstd = inps.iter().filter(|inp| inp.is_std()).count();
     if nstd > 1 {
-        return Err("At most one <stdin> input is allowed.".to_string());
+        return Err("At most one <stdin> input is allowed.".to_owned());
     }
     Ok(())
 }
@@ -130,10 +130,10 @@ pub fn range(start: Idx, end: Idx, len: Idx, index: Idx)
     match (start, end, len, index) {
         (None, None, None, Some(i)) => Ok((i, i+1)),
         (_, _, _, Some(_)) =>
-            Err("--index cannot be used with --start, --end or --len".to_string()),
+            Err("--index cannot be used with --start, --end or --len".to_owned()),
         (_, Some(_), Some(_), None) =>
-            Err("--end and --len cannot be used at the same time.".to_string()),
-        (_, None, None, None) => return Ok((start.unwrap_or(0), ::std::usize::MAX)),
+            Err("--end and --len cannot be used at the same time.".to_owned()),
+        (_, None, None, None) => Ok((start.unwrap_or(0), ::std::usize::MAX)),
         (_, Some(e), None, None) => {
             let s = start.unwrap_or(0);
             if s > e {

--- a/tests/workdir.rs
+++ b/tests/workdir.rs
@@ -6,6 +6,7 @@ use std::path::{Path, PathBuf};
 use std::process;
 use std::str::FromStr;
 use std::sync::atomic;
+use std::time::Duration;
 
 use csv;
 
@@ -143,7 +144,7 @@ fn create_dir_all<P: AsRef<Path>>(p: P) -> io::Result<()> {
     for _ in 0..10 {
         if let Err(err) = fs::create_dir_all(&p) {
             last_err = Some(err);
-            ::std::thread::sleep_ms(500);
+            ::std::thread::sleep(Duration::from_millis(500));
         } else {
             return Ok(())
         }


### PR DESCRIPTION
This is mostly small stuff, a few `to_string()`s, `map(_).unwrap_or(_)` and so on. It also fixes rustc's "privates in public" warnings which will turn into errors in a future Rust version.