### PR TITLE
Assert that split doesn't produce extra empty files

### DIFF
--- a/tests/test_split.rs
+++ b/tests/test_split.rs
@@ -55,6 +55,7 @@ h1,h2
 i,j
 k,l
 ");
+    assert!(!wrk.path("6.csv").exists());
 }
 
 #[test]
@@ -81,6 +82,7 @@ h1,h2
 i,j
 k,l
 ");
+    assert!(!wrk.path("6.csv").exists());
 }
 
 #[test]


### PR DESCRIPTION
This is a bit of a silly test case, because `xsv split` already works
correctly.  But when running very large jobs on a cluster, I
occasionally saw CSV files with zero bytes which _appeared_ to be coming
from `xsv split`.

It turned out that these files _weren't_ being generated by `xsv split`;
instead, they seemed to involve a cluster filesystem issue, which was
reported at https://github.com/pachyderm/pachyderm/issues/1452 .  But it
still seems like it would be nice to have a test case asserting that
`xsv split` never produces this behavior, if only so I can always assume
any such failures are somebody else's problem. :-)