### PR TITLE
Add help message for "<command> -h"

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -82,6 +82,7 @@ Usage:
 Options:
     --list        List all commands available.
     -h, --help    Display this message
+    <command> -h  Display the command help message
     --version     Print version info and exit
 
 Commands:", command_list!());


### PR DESCRIPTION
The user may be confused that to get the options like the very common `delimiter` option,
he has to know to use `xsv <command> -h` to discover it's `-d`. Thus, I think adding it here
or to the README may be a good idea

I'm not sure adding the line to `Options` is a good idea since `<command> -h` is not an option but this is open for discussion