### PR TITLE
Add homebrew-core installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,6 +299,13 @@ right and full outer join support too.
 
 Binaries for Windows, Linux and Mac are available [from Github](https://github.com/BurntSushi/xsv/releases/latest).
 
+If you're a **Mac OS X Homebrew** user, then you can install xsv
+from homebrew-core, (compiled with rust stable, no SIMD):
+
+```
+$ brew install xsv
+```
+
 Alternatively, you can compile from source by
 [installing Cargo](https://crates.io/install)
 ([Rust's](http://www.rust-lang.org/) package manager)


### PR DESCRIPTION
xsv was added to homebrew-core in https://github.com/Homebrew/homebrew-core/pull/11427,
so this change mentions that installation option in the readme. The
wording was adapted from ripgrep's readme:
https://github.com/BurntSushi/ripgrep/tree/685cc6c5622b02fd5a53c8bc953176b159c780e4#installation