### PR TITLE
Add type params

### DIFF
--- a/src/cmd/stats.rs
+++ b/src/cmd/stats.rs
@@ -461,21 +461,21 @@ impl TypedSum {
         }
         match typ {
             TFloat => {
-                let float: f64 = from_bytes(sample).unwrap();
+                let float: f64 = from_bytes::<f64>(sample).unwrap();
                 match self.float {
                     None => {
                         self.float = Some((self.integer as f64) + float);
                     }
-                    Some(ref mut float) => {
-                        *float += from_bytes(sample).unwrap();
+                    Some(ref mut f) => {
+                        *f += float;
                     }
                 }
             }
             TInteger => {
                 if let Some(ref mut float) = self.float {
-                    *float += from_bytes(sample).unwrap();
+                    *float += from_bytes::<f64>(sample).unwrap();
                 } else {
-                    self.integer += from_bytes(sample).unwrap();
+                    self.integer += from_bytes::<i64>(sample).unwrap();
                 }
             }
             _ => {}


### PR DESCRIPTION
There is a pull request on the rust compiler (PR [#41336](https://github.com/rust-lang/rust/pull/41336)) that will add support for `a += &b` (instead of only `a += b`) for numeric types like `i64` and `f64`.

Unfortunately, this breaks the build of xsv, because xsv currently does the following in a few places:

`*float += from_bytes(sample).unwrap();`

These lines rely on type inference to infer that `from_bytes(...)` must be `from_bytes::<f64>(...)`, but if the PR on the compiler is accepted, this inference is no longer possible because `from_bytes::<&'a f64>(...)` would also be valid.

This PR adds explicit type parameters to all `from_bytes` calls. Whether you want to merge this PR or not is entirely up to you, because it doesn't actually fix any (current) problems (besides a very minor double parse), and it's not even sure if the PR on the compiler will end up being accepted or not.