### PR TITLE
Migrate to csv crate rewrite.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,3 @@
-#language: rust
-#rust:
-#  - 1.9.0
-#  - stable
-#  - beta
-#  - nightly
-#script:
-#  - cargo build --verbose
-#  - cargo doc
-#  - cargo test --verbose
-#  - if [ "$TRAVIS_RUST_VERSION" = "nightly" ]; then
-#      cargo bench --verbose;
-#    fi
-
 language: rust
 cache: cargo
 
@@ -32,6 +18,13 @@ matrix:
       env: TARGET=x86_64-apple-darwin
     - os: linux
       rust: stable
+      env: TARGET=x86_64-unknown-linux-musl
+    # Minimum Rust supported channel.
+    - os: linux
+      rust: 1.15.0
+      env: TARGET=x86_64-unknown-linux-gnu
+    - os: linux
+      rust: 1.15.0
       env: TARGET=x86_64-unknown-linux-musl
 
 before_install:

--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -6,27 +6,27 @@ These benchmarks were run with
 which is a random 1,000,000 row subset of the world city population dataset
 from the [Data Science Toolkit](https://github.com/petewarden/dstkdata).
 
-These benchmarks were run on an Intel i3930K (6 CPUs, 12 threads) with 32GB of
-memory.
+These benchmarks were run on an Intel i7-6900K (8 CPUs, 16 threads) with 64GB
+of memory.
 
 ```
-count                   0.28 seconds    162.54 MB/sec
-flatten                 5.31 seconds    8.57 MB/sec
-flatten_condensed       5.39 seconds    8.44 MB/sec
-frequency               2.54 seconds    17.91 MB/sec
-index                   0.27 seconds    168.56 MB/sec
-sample_10               0.47 seconds    96.83 MB/sec
-sample_1000             0.49 seconds    92.88 MB/sec
-sample_100000           0.62 seconds    73.40 MB/sec
-search                  0.71 seconds    64.10 MB/sec
-select                  0.47 seconds    96.83 MB/sec
-sort                    3.36 seconds    13.54 MB/sec
-slice_one_middle        0.22 seconds    206.88 MB/sec
-slice_one_middle_index  0.01 seconds    4551.36 MB/sec
-stats                   1.37 seconds    33.22 MB/sec
-stats_index             0.23 seconds    197.88 MB/sec
-stats_everything        3.90 seconds    11.67 MB/sec
-stats_everything_index  2.58 seconds    17.64 MB/sec
+count                   0.11  seconds  413.76   MB/sec
+flatten                 4.54  seconds  10.02    MB/sec
+flatten_condensed       4.45  seconds  10.22    MB/sec
+frequency               1.82  seconds  25.00    MB/sec
+index                   0.12  seconds  379.28   MB/sec
+sample_10               0.18  seconds  252.85   MB/sec
+sample_1000             0.18  seconds  252.85   MB/sec
+sample_100000           0.29  seconds  156.94   MB/sec
+search                  0.27  seconds  168.56   MB/sec
+select                  0.14  seconds  325.09   MB/sec
+sort                    2.18  seconds  20.87    MB/sec
+slice_one_middle        0.08  seconds  568.92   MB/sec
+slice_one_middle_index  0.01  seconds  4551.36  MB/sec
+stats                   1.09  seconds  41.75    MB/sec
+stats_index             0.15  seconds  303.42   MB/sec
+stats_everything        1.94  seconds  23.46    MB/sec
+stats_everything_index  0.93  seconds  48.93    MB/sec
 ```
 
 ### Details
@@ -39,4 +39,3 @@ The `count` command can be viewed as a sort of baseline of the fastest possible
 command that parses every record in CSV data.
 
 The benchmarks that end with `_index` are run with indexing enabled.
-

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,34 +1,37 @@
 [root]
 name = "xsv"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
- "byteorder 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "chan 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "csv 0.14.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "docopt 0.6.86 (registry+https://github.com/rust-lang/crates.io-index)",
+ "csv 1.0.0-beta.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "csv-index 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "docopt 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "filetime 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "num_cpus 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "quickcheck 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quickcheck 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 0.1.80 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-serialize 0.3.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "streaming-stats 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
- "tabwriter 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tabwriter 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "threadpool 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "aho-corasick"
-version = "0.5.3"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "memchr 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "byteorder"
-version = "0.5.3"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -41,31 +44,40 @@ dependencies = [
 
 [[package]]
 name = "csv"
-version = "0.14.7"
+version = "1.0.0-beta.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "byteorder 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-serialize 0.3.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "csv-core 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "memchr 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "csv-index"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byteorder 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "csv 1.0.0-beta.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "csv-core 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "docopt"
-version = "0.6.86"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "lazy_static 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 0.1.80 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-serialize 0.3.23 (registry+https://github.com/rust-lang/crates.io-index)",
- "strsim 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "env_logger"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "log 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 0.1.80 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "strsim 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -73,7 +85,7 @@ name = "filetime"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.23 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -87,12 +99,12 @@ dependencies = [
 
 [[package]]
 name = "lazy_static"
-version = "0.2.4"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "libc"
-version = "0.2.21"
+version = "0.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -102,10 +114,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "memchr"
-version = "0.1.11"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.23 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -114,8 +126,8 @@ version = "0.1.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "num-bigint 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-complex 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-integer 0.1.33 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-complex 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-integer 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-iter 0.1.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-rational 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -126,24 +138,24 @@ name = "num-bigint"
 version = "0.1.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "num-integer 0.1.33 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-integer 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-serialize 0.3.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "num-complex"
-version = "0.1.36"
+version = "0.1.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "num-traits 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-serialize 0.3.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "num-integer"
-version = "0.1.33"
+version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "num-traits 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -154,7 +166,7 @@ name = "num-iter"
 version = "0.1.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "num-integer 0.1.33 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-integer 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -164,9 +176,9 @@ version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "num-bigint 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-integer 0.1.33 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-integer 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-serialize 0.3.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -176,51 +188,78 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "num_cpus"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.23 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "quickcheck"
-version = "0.3.2"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "env_logger 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "quote"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "rand"
 version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.23 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "regex"
-version = "0.1.80"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "aho-corasick 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "memchr 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex-syntax 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "thread_local 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "utf8-ranges 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aho-corasick 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-syntax 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thread_local 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "utf8-ranges 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "regex-syntax"
-version = "0.3.9"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "rustc-serialize"
-version = "0.3.23"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "serde"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "serde_derive"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive_internals 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "streaming-stats"
@@ -232,12 +271,30 @@ dependencies = [
 
 [[package]]
 name = "strsim"
-version = "0.5.2"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "syn"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "synom"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "tabwriter"
-version = "0.1.25"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unicode-width 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -245,19 +302,20 @@ dependencies = [
 
 [[package]]
 name = "thread-id"
-version = "2.0.0"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.23 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "thread_local"
-version = "0.2.7"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "thread-id 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thread-id 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unreachable 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -271,8 +329,26 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "unicode-xid"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "unreachable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "utf8-ranges"
-version = "0.1.3"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "void"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -286,38 +362,48 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [metadata]
-"checksum aho-corasick 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ca972c2ea5f742bfce5687b9aef75506a764f61d37f8f649047846a9686ddb66"
-"checksum byteorder 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "0fc10e8cc6b2580fda3f36eb6dc5316657f812a3df879a44a66fc9f0fdbc4855"
+"checksum aho-corasick 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "500909c4f87a9e52355b26626d890833e9e1d53ac566db76c36faa984b889699"
+"checksum byteorder 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c40977b0ee6b9885c9013cd41d9feffdd22deb3bb4dc3a71d901cc7a77de18c8"
 "checksum chan 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)" = "f93bfe971116428a9066c1c3c69a09ae3ef69432f8418be28ab50f96783e6a50"
-"checksum csv 0.14.7 (registry+https://github.com/rust-lang/crates.io-index)" = "266c1815d7ca63a5bd86284043faf91e8c95e943e55ce05dc0ae08e952de18bc"
-"checksum docopt 0.6.86 (registry+https://github.com/rust-lang/crates.io-index)" = "4a7ef30445607f6fc8720f0a0a2c7442284b629cf0d049286860fae23e71c4d9"
-"checksum env_logger 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "15abd780e45b3ea4f76b4e9a26ff4843258dd8a3eed2775a0e7368c2e7936c2f"
+"checksum csv 1.0.0-beta.1 (registry+https://github.com/rust-lang/crates.io-index)" = "81675dd89651e2aa0989e6a5249dc5c5bcfc13772baec7f9652208e7691e0955"
+"checksum csv-core 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6a11ab3094dd197341f9d66753789a5cdf29ce35450a7d6e7968024e2d44519c"
+"checksum csv-index 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7405ccdb151a01a4844b2cf851e2806dca2bdec892537057bf0719f4a7504c60"
+"checksum docopt 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ab32ea6e284d87987066f21a9e809a73c14720571ef34516f0890b3d355ccfd8"
 "checksum filetime 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "5363ab8e4139b8568a6237db5248646e5a8a2f89bd5ccb02092182b11fd3e922"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
-"checksum lazy_static 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "7291b1dd97d331f752620b02dfdbc231df7fc01bf282a00769e1cdb963c460dc"
-"checksum libc 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)" = "88ee81885f9f04bff991e306fea7c1c60a5f0f9e409e99f6b40e3311a3363135"
+"checksum lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "3b37545ab726dd833ec6420aaba8231c5b320814b9029ad585555d2a03e94fbf"
+"checksum libc 0.2.23 (registry+https://github.com/rust-lang/crates.io-index)" = "e7eb6b826bfc1fdea7935d46556250d1799b7fe2d9f7951071f4291710665e3e"
 "checksum log 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "5141eca02775a762cc6cd564d8d2c50f67c0ea3a372cbf1c51592b3e029e10ad"
-"checksum memchr 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d8b629fb514376c675b98c1421e80b151d3817ac42d7c667717d282761418d20"
+"checksum memchr 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1dbccc0e46f1ea47b9f17e6d67c5a96bd27030519c519c9c91327e31275a47b4"
 "checksum num 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)" = "98b15ba84e910ea7a1973bccd3df7b31ae282bf9d8bd2897779950c9b8303d40"
 "checksum num-bigint 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)" = "ba6d838b16e56da1b6c383d065ff1ec3c7d7797f65a3e8f6ba7092fd87820bac"
-"checksum num-complex 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)" = "3534898d8a1f6b16c12f9fc2f4eaabc7ecdcc55f267213caa8988fdc7d60ff94"
-"checksum num-integer 0.1.33 (registry+https://github.com/rust-lang/crates.io-index)" = "21e4df1098d1d797d27ef0c69c178c3fab64941559b290fcae198e0825c9c8b5"
+"checksum num-complex 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)" = "148eb324ca772230853418731ffdf13531738b50f89b30692a01fcdcb0a64677"
+"checksum num-integer 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)" = "ef1a4bf6f9174aa5783a9b4cc892cacd11aebad6c69ad027a0b65c6ca5f8aa37"
 "checksum num-iter 0.1.33 (registry+https://github.com/rust-lang/crates.io-index)" = "f7d1891bd7b936f12349b7d1403761c8a0b85a18b148e9da4429d5d102c1a41e"
 "checksum num-rational 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)" = "c2dc5ea04020a8f18318ae485c751f8cfa1c0e69dcf465c29ddaaa64a313cc44"
 "checksum num-traits 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)" = "e1cbfa3781f3fe73dc05321bed52a06d2d491eaa764c52335cf4399f046ece99"
-"checksum num_cpus 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a18c392466409c50b87369414a2680c93e739aedeb498eb2bff7d7eb569744e2"
-"checksum quickcheck 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0b333da40686cc05db13d933f8e7b450f403cfc5a4d005154d8d4a5ba9d14605"
+"checksum num_cpus 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ca313f1862c7ec3e0dfe8ace9fa91b1d9cb5c84ace3d00f5ec4216238e93c167"
+"checksum quickcheck 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "02c2411d418cea2364325b18a205664f9ef8252e06b2e911db97c0b0d98b1406"
+"checksum quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
 "checksum rand 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "022e0636ec2519ddae48154b028864bdce4eaf7d35226ab8e65c611be97b189d"
-"checksum regex 0.1.80 (registry+https://github.com/rust-lang/crates.io-index)" = "4fd4ace6a8cf7860714a2c2280d6c1f7e6a413486c13298bbc86fd3da019402f"
-"checksum regex-syntax 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "f9ec002c35e86791825ed294b50008eea9ddfc8def4420124fbc6b08db834957"
-"checksum rustc-serialize 0.3.23 (registry+https://github.com/rust-lang/crates.io-index)" = "684ce48436d6465300c9ea783b6b14c4361d6b8dcbb1375b486a69cc19e2dfb0"
+"checksum regex 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1731164734096285ec2a5ec7fea5248ae2f5485b3feeb0115af4fda2183b2d1b"
+"checksum regex-syntax 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ad890a5eef7953f55427c50575c680c42841653abd2b028b68cd223d157f62db"
+"checksum rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)" = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
+"checksum serde 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)" = "c0c3d79316a6051231925504f6ef893d45088e8823c77a8331a3dcf427ee9087"
+"checksum serde_derive 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)" = "0019cd5b9f0529a1a0e145a912e9a2d60c325c58f7f260fc36c71976e9d76aee"
+"checksum serde_derive_internals 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)" = "021c338d22c7e30f957a6ab7e388cb6098499dda9fd4ba1661ee074ca7a180d1"
 "checksum streaming-stats 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)" = "f13d0cd680e11a62c5e125d9799debfb39fcfff9a2ef416336ce748f65018b89"
-"checksum strsim 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "67f84c44fbb2f91db7fef94554e6b2ac05909c9c0b0bc23bb98d3a1aebfe7f7c"
-"checksum tabwriter 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)" = "85dbf563da2891d55ef4b00ef08c5b5f160143f67691ff1f97ad89e77824ed3b"
-"checksum thread-id 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a9539db560102d1cef46b8b78ce737ff0bb64e7e18d35b2a5688f7d097d0ff03"
-"checksum thread_local 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "8576dbbfcaef9641452d5cf0df9b0e7eeab7694956dd33bb61515fb8f18cfdd5"
+"checksum strsim 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b4d15c810519a91cf877e7e36e63fe068815c678181439f2f29e2562147c3694"
+"checksum syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
+"checksum synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
+"checksum tabwriter 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3b7810162bc0a2eb2dc9a9bfd16ddb2d1f6022df3236d1478937bfadcb12385e"
+"checksum thread-id 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8df7875b676fddfadffd96deea3b1124e5ede707d4884248931077518cf1f773"
+"checksum thread_local 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c85048c6260d17cf486ceae3282d9fb6b90be220bf5b28c400f5485ffc29f0c7"
 "checksum threadpool 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "59f6d3eff89920113dac9db44dde461d71d01e88a5b57b258a0466c32b5d7fe1"
 "checksum unicode-width 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "bf3a113775714a22dcb774d8ea3655c53a32debae63a063acc00a91cc586245f"
-"checksum utf8-ranges 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a1ca13c08c41c9c3e04224ed9ff80461d97e121589ff27c753a16cb10830ae0f"
+"checksum unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f860d7d29cf02cb2f3f359fd35991af3d30bac52c57d265a3c461074cb4dc"
+"checksum unreachable 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1f2ae5ddb18e1c92664717616dd9549dde73f539f01bd7b77c2edb2446bdff91"
+"checksum utf8-ranges 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "662fab6525a98beff2921d7f61a39e7d59e0b425ebc7d0d9e66d316e55124122"
+"checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 "checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xsv"
-version = "0.11.0"  #:version
+version = "0.12.0"  #:version
 authors = ["Andrew Gallant <jamslam@gmail.com>"]
 description = "A high performance CSV command line toolkit."
 documentation = "http://burntsushi.net/rustdoc/xsv/"
@@ -26,19 +26,22 @@ opt-level = 3
 opt-level = 3
 
 [dependencies]
-byteorder = "0.5"
+byteorder = "1"
 chan = "0.1"
-csv = "0.14"
-docopt = "0.6"
+csv = "1.0.0-beta.1"
+csv-index = "0.1"
+docopt = "0.7"
 filetime = "0.1"
-num_cpus = "1.0"
-rand = "0.3"
-regex = "0.1"
+num_cpus = "1.4"
+rand = "0.3.15"
+regex = "0.2"
 rustc-serialize = "0.3"
 streaming-stats = "0.1"
-tabwriter = "0.1"
+tabwriter = "1"
 threadpool = "1.3"
 
 [dev-dependencies]
-quickcheck = "0.3"
+quickcheck = { version = "0.4", default-features = false }
 log = "0.3"
+serde = "1"
+serde_derive = "1"

--- a/README.md
+++ b/README.md
@@ -300,7 +300,7 @@ right and full outer join support too.
 Binaries for Windows, Linux and Mac are available [from Github](https://github.com/BurntSushi/xsv/releases/latest).
 
 If you're a **Mac OS X Homebrew** user, then you can install xsv
-from homebrew-core, (compiled with rust stable, no SIMD):
+from homebrew-core:
 
 ```
 $ brew install xsv
@@ -309,7 +309,13 @@ $ brew install xsv
 Alternatively, you can compile from source by
 [installing Cargo](https://crates.io/install)
 ([Rust's](http://www.rust-lang.org/) package manager)
-and building `xsv`:
+and installing `xsv` using Cargo:
+
+```bash
+cargo install xsv
+```
+
+Compiling from this repository also works similarly:
 
 ```bash
 git clone git://github.com/BurntSushi/xsv
@@ -317,7 +323,7 @@ cd xsv
 cargo build --release
 ```
 
-Compilation will probably take 1-2 minutes depending on your machine. The
+Compilation will probably take a few minutes depending on your machine. The
 binary will end up in `./target/release/xsv`.
 
 

--- a/src/cmd/join.rs
+++ b/src/cmd/join.rs
@@ -6,11 +6,11 @@ use std::iter::repeat;
 use std::str;
 
 use byteorder::{WriteBytesExt, BigEndian};
-use csv::{self, ByteString};
-use csv::index::Indexed;
+use csv;
 
 use CliResult;
 use config::{Config, Delimiter};
+use index::Indexed;
 use select::{SelectColumns, Selection};
 use util;
 
@@ -71,6 +71,8 @@ Common options:
                            Must be a single character. (default: ,)
 ";
 
+type ByteString = Vec<u8>;
+
 #[derive(RustcDecodable)]
 struct Args {
     arg_columns1: SelectColumns,
@@ -89,8 +91,8 @@ struct Args {
 }
 
 pub fn run(argv: &[&str]) -> CliResult<()> {
-    let args: Args = try!(util::get_args(USAGE, argv));
-    let mut state = try!(args.new_io_state());
+    let args: Args = util::get_args(USAGE, argv)?;
+    let mut state = args.new_io_state()?;
     match (
         args.flag_left,
         args.flag_right,
@@ -98,23 +100,23 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
         args.flag_cross,
     ) {
         (true, false, false, false) => {
-            try!(state.write_headers());
+            state.write_headers()?;
             state.outer_join(false)
         }
         (false, true, false, false) => {
-            try!(state.write_headers());
+            state.write_headers()?;
             state.outer_join(true)
         }
         (false, false, true, false) => {
-            try!(state.write_headers());
+            state.write_headers()?;
             state.full_outer_join()
         }
         (false, false, false, true) => {
-            try!(state.write_headers());
+            state.write_headers()?;
             state.cross_join()
         }
         (false, false, false, false) => {
-            try!(state.write_headers());
+            state.write_headers()?;
             state.inner_join()
         }
         _ => fail!("Please pick exactly one join operation.")
@@ -135,29 +137,29 @@ struct IoState<R, W: io::Write> {
 impl<R: io::Read + io::Seek, W: io::Write> IoState<R, W> {
     fn write_headers(&mut self) -> CliResult<()> {
         if !self.no_headers {
-            let mut headers = try!(self.rdr1.byte_headers());
-            headers.extend(try!(self.rdr2.byte_headers()).into_iter());
-            try!(self.wtr.write(headers.into_iter()));
+            let mut headers = self.rdr1.byte_headers()?.clone();
+            headers.extend(self.rdr2.byte_headers()?.iter());
+            self.wtr.write_record(&headers)?;
         }
         Ok(())
     }
 
     fn inner_join(mut self) -> CliResult<()> {
-        let mut validx = try!(ValueIndex::new(self.rdr2, &self.sel2,
-                                              self.casei, self.nulls));
+        let mut scratch = csv::ByteRecord::new();
+        let mut validx = ValueIndex::new(
+            self.rdr2, &self.sel2, self.casei, self.nulls)?;
         for row in self.rdr1.byte_records() {
-            let row = try!(row);
+            let row = row?;
             let key = get_row_key(&self.sel1, &row, self.casei);
             match validx.values.get(&key) {
                 None => continue,
                 Some(rows) => {
                     for &rowi in rows.iter() {
-                        try!(validx.idx.seek(rowi as u64));
+                        validx.idx.seek(rowi as u64)?;
 
-                        let mut row1 = row.iter().map(|f| Ok(&**f));
-                        let row2 = unsafe { validx.idx.byte_fields() };
-                        let combined = row1.by_ref().chain(row2);
-                        try!(self.wtr.write_iter(combined));
+                        validx.idx.read_byte_record(&mut scratch)?;
+                        let combined = row.iter().chain(scratch.iter());
+                        self.wtr.write_record(combined)?;
                     }
                 }
             }
@@ -171,33 +173,30 @@ impl<R: io::Read + io::Seek, W: io::Write> IoState<R, W> {
             ::std::mem::swap(&mut self.sel1, &mut self.sel2);
         }
 
-        let (_, pad2) = try!(self.get_padding());
-        let mut validx = try!(ValueIndex::new(self.rdr2, &self.sel2,
-                                              self.casei, self.nulls));
+        let mut scratch = csv::ByteRecord::new();
+        let (_, pad2) = self.get_padding()?;
+        let mut validx = ValueIndex::new(
+            self.rdr2, &self.sel2, self.casei, self.nulls)?;
         for row in self.rdr1.byte_records() {
-            let row = try!(row);
-            let key = get_row_key(&self.sel1, &*row, self.casei);
+            let row = row?;
+            let key = get_row_key(&self.sel1, &row, self.casei);
             match validx.values.get(&key) {
                 None => {
-                    let row1 = row.iter().map(|f| Ok(&**f));
-                    let row2 = pad2.iter().map(|f| Ok(&**f));
                     if right {
-                        try!(self.wtr.write_iter(row2.chain(row1)));
+                        self.wtr.write_record(pad2.iter().chain(&row))?;
                     } else {
-                        try!(self.wtr.write_iter(row1.chain(row2)));
+                        self.wtr.write_record(row.iter().chain(&pad2))?;
                     }
                 }
                 Some(rows) => {
                     for &rowi in rows.iter() {
-                        try!(validx.idx.seek(rowi as u64));
-                        let row1 = row.iter().map(|f| Ok(&**f));
-                        let row2 = unsafe {
-                            validx.idx.byte_fields()
-                        };
+                        validx.idx.seek(rowi as u64)?;
+                        let row1 = row.iter();
+                        validx.idx.read_byte_record(&mut scratch)?;
                         if right {
-                            try!(self.wtr.write_iter(row2.chain(row1)));
+                            self.wtr.write_record(scratch.iter().chain(row1))?;
                         } else {
-                            try!(self.wtr.write_iter(row1.chain(row2)));
+                            self.wtr.write_record(row1.chain(&scratch))?;
                         }
                     }
                 }
@@ -207,32 +206,28 @@ impl<R: io::Read + io::Seek, W: io::Write> IoState<R, W> {
     }
 
     fn full_outer_join(mut self) -> CliResult<()> {
-        let (pad1, pad2) = try!(self.get_padding());
-        let mut validx = try!(ValueIndex::new(self.rdr2, &self.sel2,
-                                              self.casei, self.nulls));
+        let mut scratch = csv::ByteRecord::new();
+        let (pad1, pad2) = self.get_padding()?;
+        let mut validx = ValueIndex::new(
+            self.rdr2, &self.sel2, self.casei, self.nulls)?;
 
         // Keep track of which rows we've written from rdr2.
         let mut rdr2_written: Vec<_> =
             repeat(false).take(validx.num_rows).collect();
         for row1 in self.rdr1.byte_records() {
-            let row1 = try!(row1);
-            let key = get_row_key(&self.sel1, &*row1, self.casei);
+            let row1 = row1?;
+            let key = get_row_key(&self.sel1, &row1, self.casei);
             match validx.values.get(&key) {
                 None => {
-                    let row1 = row1.iter().map(|f| Ok(&**f));
-                    let row2 = pad2.iter().map(|f| Ok(&**f));
-                    try!(self.wtr.write_iter(row1.chain(row2)));
+                    self.wtr.write_record(row1.iter().chain(&pad2))?;
                 }
                 Some(rows) => {
                     for &rowi in rows.iter() {
                         rdr2_written[rowi] = true;
 
-                        try!(validx.idx.seek(rowi as u64));
-                        let row1 = row1.iter().map(|f| Ok(&**f));
-                        let row2 = unsafe {
-                            validx.idx.byte_fields()
-                        };
-                        try!(self.wtr.write_iter(row1.chain(row2)));
+                        validx.idx.seek(rowi as u64)?;
+                        validx.idx.read_byte_record(&mut scratch)?;
+                        self.wtr.write_record(row1.iter().chain(&scratch))?;
                     }
                 }
             }
@@ -242,46 +237,41 @@ impl<R: io::Read + io::Seek, W: io::Write> IoState<R, W> {
         // from rdr1.
         for (i, &written) in rdr2_written.iter().enumerate() {
             if !written {
-                try!(validx.idx.seek(i as u64));
-                let row1 = pad1.iter().map(|f| Ok(&**f));
-                let row2 = unsafe {
-                    validx.idx.byte_fields()
-                };
-                try!(self.wtr.write_iter(row1.chain(row2)));
+                validx.idx.seek(i as u64)?;
+                validx.idx.read_byte_record(&mut scratch)?;
+                self.wtr.write_record(pad1.iter().chain(&scratch))?;
             }
         }
         Ok(())
     }
 
     fn cross_join(mut self) -> CliResult<()> {
+        let mut pos = csv::Position::new();
+        pos.set_byte(0);
+        let mut row2 = csv::ByteRecord::new();
         for row1 in self.rdr1.byte_records() {
-            let row1 = try!(row1);
-
-            try!(self.rdr2.seek(0));
-            let mut first = true;
-            while !self.rdr2.done() {
-                // Skip the header row. The raw byte interface won't
-                // do it for us.
-                if first && !self.no_headers {
-                    while let Some(f) =
-                        self.rdr2.next_bytes().into_iter_result() { try!(f); }
-                    first = false;
-                }
-                let row1 = row1.iter().map(|f| Ok(&**f));
-                let row2 = unsafe { self.rdr2.byte_fields() };
-                try!(self.wtr.write_iter(row1.chain(row2)));
+            let row1 = row1?;
+            self.rdr2.seek(pos.clone())?;
+            if self.rdr2.has_headers() {
+                // Read and skip the header row, since CSV readers disable
+                // the header skipping logic after being seeked.
+                self.rdr2.read_byte_record(&mut row2)?;
+            }
+            while self.rdr2.read_byte_record(&mut row2)? {
+                self.wtr.write_record(row1.iter().chain(&row2))?;
             }
         }
         Ok(())
     }
 
-    fn get_padding(&mut self)
-                  -> CliResult<(Vec<ByteString>, Vec<ByteString>)> {
-        let len1 = try!(self.rdr1.byte_headers()).len();
-        let len2 = try!(self.rdr2.byte_headers()).len();
+    fn get_padding(
+        &mut self,
+    ) -> CliResult<(csv::ByteRecord, csv::ByteRecord)> {
+        let len1 = self.rdr1.byte_headers()?.len();
+        let len2 = self.rdr2.byte_headers()?.len();
         Ok((
-            repeat(util::empty_field()).take(len1).collect(),
-            repeat(util::empty_field()).take(len2).collect(),
+            repeat(b"").take(len1).collect(),
+            repeat(b"").take(len2).collect(),
         ))
     }
 }
@@ -290,20 +280,20 @@ impl Args {
     fn new_io_state(&self)
         -> CliResult<IoState<fs::File, Box<io::Write+'static>>> {
         let rconf1 = Config::new(&Some(self.arg_input1.clone()))
-                            .delimiter(self.flag_delimiter)
-                            .no_headers(self.flag_no_headers)
-                            .select(self.arg_columns1.clone());
+            .delimiter(self.flag_delimiter)
+            .no_headers(self.flag_no_headers)
+            .select(self.arg_columns1.clone());
         let rconf2 = Config::new(&Some(self.arg_input2.clone()))
-                            .delimiter(self.flag_delimiter)
-                            .no_headers(self.flag_no_headers)
-                            .select(self.arg_columns2.clone());
+            .delimiter(self.flag_delimiter)
+            .no_headers(self.flag_no_headers)
+            .select(self.arg_columns2.clone());
 
-        let mut rdr1 = try!(rconf1.reader_file());
-        let mut rdr2 = try!(rconf2.reader_file());
-        let (sel1, sel2) = try!(self.get_selections(&rconf1, &mut rdr1,
-                                                    &rconf2, &mut rdr2));
+        let mut rdr1 = rconf1.reader_file()?;
+        let mut rdr2 = rconf2.reader_file()?;
+        let (sel1, sel2) = self.get_selections(
+            &rconf1, &mut rdr1, &rconf2, &mut rdr2)?;
         Ok(IoState {
-            wtr: try!(Config::new(&self.flag_output).writer()),
+            wtr: Config::new(&self.flag_output).writer()?,
             rdr1: rdr1,
             sel1: sel1,
             rdr2: rdr2,
@@ -314,15 +304,15 @@ impl Args {
         })
     }
 
-    fn get_selections<R: io::Read>
-                     (&self,
-                      rconf1: &Config, rdr1: &mut csv::Reader<R>,
-                      rconf2: &Config, rdr2: &mut csv::Reader<R>)
-                     -> CliResult<(Selection, Selection)> {
-        let headers1 = try!(rdr1.byte_headers());
-        let headers2 = try!(rdr2.byte_headers());
-        let select1 = try!(rconf1.selection(&*headers1));
-        let select2 = try!(rconf2.selection(&*headers2));
+    fn get_selections<R: io::Read>(
+        &self,
+        rconf1: &Config, rdr1: &mut csv::Reader<R>,
+        rconf2: &Config, rdr2: &mut csv::Reader<R>,
+    ) -> CliResult<(Selection, Selection)> {
+        let headers1 = rdr1.byte_headers()?;
+        let headers2 = rdr2.byte_headers()?;
+        let select1 = rconf1.selection(&*headers1)?;
+        let select2 = rconf2.selection(&*headers2)?;
         if select1.len() != select2.len() {
             return fail!(format!(
                 "Column selections must have the same number of columns, \
@@ -341,40 +331,44 @@ struct ValueIndex<R> {
 }
 
 impl<R: io::Read + io::Seek> ValueIndex<R> {
-    fn new(mut rdr: csv::Reader<R>, sel: &Selection,
-           casei: bool, nulls: bool)
-          -> CliResult<ValueIndex<R>> {
+    fn new(
+        mut rdr: csv::Reader<R>,
+        sel: &Selection,
+        casei: bool,
+        nulls: bool,
+    ) -> CliResult<ValueIndex<R>> {
         let mut val_idx = HashMap::with_capacity(10000);
         let mut row_idx = io::Cursor::new(Vec::with_capacity(8 * 10000));
         let (mut rowi, mut count) = (0usize, 0usize);
-        let row_len = try!(rdr.byte_headers()).len();
 
         // This logic is kind of tricky. Basically, we want to include
         // the header row in the line index (because that's what csv::index
         // does), but we don't want to include header values in the ValueIndex.
-        if !rdr.has_headers {
+        if !rdr.has_headers() {
             // ... so if there are no headers, we seek to the beginning and
             // index everything.
-            try!(rdr.seek(0));
+            let mut pos = csv::Position::new();
+            pos.set_byte(0);
+            rdr.seek(pos)?;
         } else {
             // ... and if there are headers, we make sure that we've parsed
             // them, and write the offset of the header row to the index.
-            try!(rdr.byte_headers());
-            try!(row_idx.write_u64::<BigEndian>(0));
+            rdr.byte_headers()?;
+            row_idx.write_u64::<BigEndian>(0)?;
             count += 1;
         }
-        while !rdr.done() {
-            // This is a bit hokey. We're doing this manually instead of
-            // calling `csv::index::create` so we can create both indexes
-            // in one pass.
-            try!(row_idx.write_u64::<BigEndian>(rdr.byte_offset()));
 
-            let mut row = Vec::with_capacity(row_len);
-            while let Some(r) = rdr.next_bytes().into_iter_result() {
-                row.push(try!(r).to_vec());
-            }
+        let mut row = csv::ByteRecord::new();
+        while rdr.read_byte_record(&mut row)? {
+            // This is a bit hokey. We're doing this manually instead of using
+            // the `csv-index` crate directly so that we can create both
+            // indexes in one pass.
+            row_idx.write_u64::<BigEndian>(row.position().unwrap().byte())?;
 
-            let fields: Vec<_> = sel.select(&row).map(|v| transform(v, casei)).collect();
+            let fields: Vec<_> = sel
+                .select(&row)
+                .map(|v| transform(v, casei))
+                .collect();
             if nulls || !fields.iter().any(|f| f.is_empty()) {
                 match val_idx.entry(fields) {
                     Entry::Vacant(v) => {
@@ -382,17 +376,20 @@ impl<R: io::Read + io::Seek> ValueIndex<R> {
                         rows.push(rowi);
                         v.insert(rows);
                     }
-                    Entry::Occupied(mut v) => { v.get_mut().push(rowi); }
+                    Entry::Occupied(mut v) => {
+                        v.get_mut().push(rowi);
+                    }
                 }
             }
             rowi += 1;
             count += 1;
         }
-        try!(row_idx.write_u64::<BigEndian>(count as u64));
+
+        row_idx.write_u64::<BigEndian>(count as u64)?;
+        let idx = Indexed::open(rdr, io::Cursor::new(row_idx.into_inner()))?;
         Ok(ValueIndex {
             values: val_idx,
-            idx: try!(Indexed::open(rdr,
-                                    io::Cursor::new(row_idx.into_inner()))),
+            idx: idx,
             num_rows: rowi,
         })
     }
@@ -408,14 +405,17 @@ impl<R> fmt::Debug for ValueIndex<R> {
             let keys = keys.iter()
                            .map(|k| String::from_utf8(k.to_vec()).unwrap())
                            .collect::<Vec<_>>();
-            try!(writeln!(f, "({}) => {:?}", keys.connect(", "), rows))
+            writeln!(f, "({}) => {:?}", keys.join(", "), rows)?
         }
         Ok(())
     }
 }
 
-fn get_row_key(sel: &Selection, row: &[ByteString], casei: bool)
-              -> Vec<ByteString> {
+fn get_row_key(
+    sel: &Selection,
+    row: &csv::ByteRecord,
+    casei: bool,
+) -> Vec<ByteString> {
     sel.select(row).map(|v| transform(&v, casei)).collect()
 }
 

--- a/src/cmd/sort.rs
+++ b/src/cmd/sort.rs
@@ -43,54 +43,53 @@ struct Args {
 }
 
 pub fn run(argv: &[&str]) -> CliResult<()> {
-    let args: Args = try!(util::get_args(USAGE, argv));
-
+    let args: Args = util::get_args(USAGE, argv)?;
     let numeric = args.flag_numeric;
     let reverse = args.flag_reverse;
     let rconfig = Config::new(&args.arg_input)
-                         .delimiter(args.flag_delimiter)
-                         .no_headers(args.flag_no_headers)
-                         .select(args.flag_select);
+        .delimiter(args.flag_delimiter)
+        .no_headers(args.flag_no_headers)
+        .select(args.flag_select);
 
-    let mut rdr = try!(rconfig.reader());
-    let mut wtr = try!(Config::new(&args.flag_output).writer());
+    let mut rdr = rconfig.reader()?;
+    let mut wtr = Config::new(&args.flag_output).writer()?;
 
-    let headers = try!(rdr.byte_headers());
-    let sel = try!(rconfig.selection(&*headers));
+    let headers = rdr.byte_headers()?.clone();
+    let sel = rconfig.selection(&headers)?;
 
-    let mut all = try!(rdr.byte_records().collect::<Result<Vec<_>, _>>());
+    let mut all = rdr.byte_records().collect::<Result<Vec<_>, _>>()?;
     match (numeric, reverse) {
         (false, false) =>
             all.sort_by(|r1, r2| {
-                let a = sel.select(r1.as_slice());
-                let b = sel.select(r2.as_slice());
+                let a = sel.select(r1);
+                let b = sel.select(r2);
                 iter_cmp(a, b)
             }),
         (true, false) =>
             all.sort_by(|r1, r2| {
-                let a = sel.select(r1.as_slice());
-                let b = sel.select(r2.as_slice());
+                let a = sel.select(r1);
+                let b = sel.select(r2);
                 iter_cmp_num(a, b)
             }),
         (false, true) =>
             all.sort_by(|r1, r2| {
-                let a = sel.select(r1.as_slice());
-                let b = sel.select(r2.as_slice());
+                let a = sel.select(r1);
+                let b = sel.select(r2);
                 iter_cmp(b, a)
             }),
         (true, true) =>
             all.sort_by(|r1, r2| {
-                let a = sel.select(r1.as_slice());
-                let b = sel.select(r2.as_slice());
+                let a = sel.select(r1);
+                let b = sel.select(r2);
                 iter_cmp_num(b, a)
             }),
     }
 
-    try!(rconfig.write_headers(&mut rdr, &mut wtr));
+    rconfig.write_headers(&mut rdr, &mut wtr)?;
     for r in all.into_iter() {
-        try!(wtr.write(r.into_iter()));
+        wtr.write_record(&r)?;
     }
-    Ok(try!(wtr.flush()))
+    Ok(wtr.flush()?)
 }
 
 /// Order `a` and `b` lexicographically using `Ord`

--- a/src/index.rs
+++ b/src/index.rs
@@ -1,0 +1,61 @@
+use std::io;
+use std::ops;
+
+use csv;
+use csv_index::RandomAccessSimple;
+
+use CliResult;
+
+/// Indexed composes a CSV reader with a simple random access index.
+pub struct Indexed<R, I> {
+    csv_rdr: csv::Reader<R>,
+    idx: RandomAccessSimple<I>,
+}
+
+impl<R, I> ops::Deref for Indexed<R, I> {
+    type Target = csv::Reader<R>;
+    fn deref(&self) -> &csv::Reader<R> { &self.csv_rdr }
+}
+
+impl<R, I> ops::DerefMut for Indexed<R, I> {
+    fn deref_mut(&mut self) -> &mut csv::Reader<R> { &mut self.csv_rdr }
+}
+
+impl<R: io::Read + io::Seek, I: io::Read + io::Seek> Indexed<R, I> {
+    /// Opens an index.
+    pub fn open(
+        csv_rdr: csv::Reader<R>,
+        idx_rdr: I,
+    ) -> CliResult<Indexed<R, I>> {
+        Ok(Indexed {
+            csv_rdr: csv_rdr,
+            idx: RandomAccessSimple::open(idx_rdr)?,
+        })
+    }
+
+    /// Return the number of records (not including the header record) in this
+    /// index.
+    pub fn count(&self) -> u64 {
+        if self.csv_rdr.has_headers() && !self.idx.is_empty() {
+            self.idx.len() - 1
+        } else {
+            self.idx.len()
+        }
+    }
+
+    /// Seek to the starting position of record `i`.
+    pub fn seek(&mut self, mut i: u64) -> CliResult<()> {
+        if i >= self.count() {
+            let msg = format!(
+                "invalid record index {} (there are {} records)",
+                i, self.count());
+            return fail!(io::Error::new(io::ErrorKind::Other, msg));
+        }
+        if self.csv_rdr.has_headers() {
+            i += 1;
+        }
+        let pos = self.idx.get(i)?;
+        self.csv_rdr.seek(pos)?;
+        Ok(())
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,12 +1,7 @@
-/*!
-These are some docs.
-*/
-
-#![allow(deprecated)] // for connect -> join rename
-
 extern crate byteorder;
 extern crate chan;
 extern crate csv;
+extern crate csv_index;
 extern crate docopt;
 extern crate filetime;
 extern crate num_cpus;
@@ -71,6 +66,7 @@ macro_rules! command_list {
 
 mod cmd;
 mod config;
+mod index;
 mod select;
 mod util;
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -51,7 +51,7 @@ pub fn many_configs(inps: &[String], delim: Option<Delimiter>,
                                     .delimiter(delim)
                                     .no_headers(no_headers))
                     .collect::<Vec<_>>();
-    try!(errif_greater_one_stdin(&*confs));
+    errif_greater_one_stdin(&*confs)?;
     Ok(confs)
 }
 
@@ -62,8 +62,6 @@ pub fn errif_greater_one_stdin(inps: &[Config]) -> Result<(), String> {
     }
     Ok(())
 }
-
-pub fn empty_field() -> csv::ByteString { vec![] }
 
 pub fn chunk_size(nitems: usize, njobs: usize) -> usize {
     if nitems < njobs {
@@ -93,11 +91,6 @@ pub fn condense<'a>(val: Cow<'a, [u8]>, n: Option<usize>) -> Cow<'a, [u8]> {
     match n {
         None => val,
         Some(n) => {
-            // It would be much nicer to just use a `match` here, but the
-            // borrow checker won't allow it. ---AG
-            //
-            // (We could circumvent it by allocating a new Unicode string,
-            // but that seems excessive.)
             let mut is_short_utf8 = false;
             if let Ok(s) = str::from_utf8(&*val) {
                 if n >= s.chars().count() {
@@ -212,7 +205,7 @@ impl FilenameTemplate {
 
 impl Decodable for FilenameTemplate {
     fn decode<D: Decoder>(d: &mut D) -> Result<FilenameTemplate, D::Error> {
-        let raw = try!(d.read_str());
+        let raw = d.read_str()?;
         let chunks = raw.split("{}").collect::<Vec<_>>();
         if chunks.len() == 2 {
             Ok(FilenameTemplate {

--- a/tests/test_frequency.rs
+++ b/tests/test_frequency.rs
@@ -166,7 +166,7 @@ fn param_prop_frequency(name: &str, rows: CsvData, idx: bool) -> bool {
 
 type FTables = HashMap<String, Frequencies<String>>;
 
-#[derive(RustcDecodable)]
+#[derive(Deserialize, RustcDecodable)]
 struct FRow {
     field: String,
     value: String,
@@ -197,9 +197,9 @@ fn ftables_from_rows<T: Csv>(rows: T) -> FTables {
 }
 
 fn ftables_from_csv_string(data: String) -> FTables {
-    let mut rdr = csv::Reader::from_string(data);
+    let mut rdr = csv::Reader::from_reader(data.as_bytes());
     let mut ftables = HashMap::new();
-    for frow in rdr.decode() {
+    for frow in rdr.deserialize() {
         let frow: FRow = frow.unwrap();
         match ftables.entry(frow.field) {
             Entry::Vacant(v) => {

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,5 +1,10 @@
-#[macro_use] extern crate log;
+#![allow(dead_code)]
+
+#[macro_use]
+extern crate log;
 extern crate rustc_serialize;
+#[macro_use]
+extern crate serde_derive;
 
 extern crate csv;
 extern crate filetime;


### PR DESCRIPTION
This commit resists the urge to refactor/rewrite xsv and ports it over
to the new CSV API. It made a lot of things cleaner and even improved
the performance of core commands like `count`, `sample`, `search`,
`select` and `slice`.

This also removes the last remaining (dubious) uses of `unsafe` within
xsv.

Benchmarks before/after:

    benchmark               before                      after
    count                   0.26s   175.05  MB/sec      0.11   413.76  MB/sec
    flatten                 4.53s   10.04   MB/sec      4.54   10.02   MB/sec
    flatten_condensed       4.72s   9.64    MB/sec      4.45   10.22   MB/sec
    frequency               1.91s   23.82   MB/sec      1.82   25.00   MB/sec
    index                   0.28s   162.54  MB/sec      0.12   379.28  MB/sec
    sample_10               0.43s   105.84  MB/sec      0.18   252.85  MB/sec
    sample_1000             0.44s   103.44  MB/sec      0.18   252.85  MB/sec
    sample_100000           0.50s   91.02   MB/sec      0.29   156.94  MB/sec
    search                  0.59s   77.14   MB/sec      0.27   168.56  MB/sec
    select                  0.41s   111.00  MB/sec      0.14   325.09  MB/sec
    sort                    2.59s   17.57   MB/sec      2.18   20.87   MB/sec
    slice_one_middle        0.22s   206.88  MB/sec      0.08   568.92  MB/sec
    slice_one_middle_index  0.01s   4551.36 MB/sec      0.01   4551.36 MB/sec
    stats                   1.26s   36.12   MB/sec      1.09   41.75   MB/sec
    stats_index             0.19s   239.54  MB/sec      0.15   303.42  MB/sec
    stats_everything        2.13s   21.36   MB/sec      1.94   23.46   MB/sec
    stats_everything_index  1.00s   45.51   MB/sec      0.93   48.93   MB/sec