### PR TITLE
Correct the version number

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xsv"
-version = "0.12.0"  #:version
+version = "0.12.1"  #:version
 authors = ["Andrew Gallant <jamslam@gmail.com>"]
 description = "A high performance CSV command line toolkit."
 documentation = "http://burntsushi.net/rustdoc/xsv/"


### PR DESCRIPTION
Correct the version number in tag 0.12.1 so that version 0.12.1 displays the correct number.
I use NixOS which uses the Nix package manager. It compiles packages from source and so it pulls down the source with the incorrect version number and compiles it.