### PR TITLE
sort.rs: do not change the output delimiter

### DIFF
--- a/src/cmd/sort.rs
+++ b/src/cmd/sort.rs
@@ -86,7 +86,9 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
             }),
     }
 
-    let mut wtr = Config::new(&args.flag_output).writer()?;
+    let mut wtr = Config::new(&args.flag_output)
+        .delimiter(args.flag_delimiter)
+        .writer()?;
     rconfig.write_headers(&mut rdr, &mut wtr)?;
     for r in all.into_iter() {
         wtr.write_byte_record(&r)?;


### PR DESCRIPTION
This commit makes sort to use the same delimiter
in the output as in the input.

The particular use-case was to sort a passwd file,
where the delimiter must be a colon (:).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/burntsushi/xsv/128)
<!-- Reviewable:end -->
