### PR TITLE
Fix error message to list out possible subcommands in lower case

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -138,6 +138,7 @@ Please choose one of the following commands:",
 }
 
 #[derive(Debug, Deserialize)]
+#[serde(rename_all = "lowercase")]
 enum Command {
     Cat,
     Count,

--- a/src/main.rs
+++ b/src/main.rs
@@ -170,7 +170,9 @@ impl Command {
         let argv = &*argv;
 
         if !argv[1].chars().all(char::is_lowercase) {
-            return Err(CliError::Other("xsv expects commands in lowercase.".to_string()));
+            return Err(CliError::Other(format!(
+                "xsv expects commands in lowercase. Did you mean '{}'?", 
+                argv[1].to_lowercase()).to_string()));
         }
         match self {
             Command::Cat => cmd::cat::run(argv),

--- a/src/main.rs
+++ b/src/main.rs
@@ -168,6 +168,10 @@ impl Command {
         let argv: Vec<_> = env::args().map(|v| v.to_owned()).collect();
         let argv: Vec<_> = argv.iter().map(|s| &**s).collect();
         let argv = &*argv;
+
+        if !argv[1].chars().all(char::is_lowercase) {
+            return Err(CliError::Other("xsv expects commands in lowercase.".to_string()));
+        }
         match self {
             Command::Cat => cmd::cat::run(argv),
             Command::Count => cmd::count::run(argv),


### PR DESCRIPTION
Fix error message to list out possible subcommands in lower case.
Warn user when subcommand is not provided in lowercase.

Fix #138 