### PR TITLE
Add instructions to install xsv from MacPorts

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,9 +299,9 @@ right and full outer join support too.
 
 ### Installation
 
-Binaries for Windows, Linux and Mac are available [from Github](https://github.com/BurntSushi/xsv/releases/latest).
+Binaries for Windows, Linux and macOS are available [from Github](https://github.com/BurntSushi/xsv/releases/latest).
 
-If you're a **Mac OS X Homebrew** user, then you can install xsv
+If you're a **macOS Homebrew** user, then you can install xsv
 from homebrew-core:
 
 ```

--- a/README.md
+++ b/README.md
@@ -308,6 +308,13 @@ from homebrew-core:
 $ brew install xsv
 ```
 
+If you're a **macOS MacPorts** user, then you can install xsv
+from the [official ports](https://www.macports.org/ports.php?by=name&substr=xsv):
+
+```
+$ sudo port install xsv
+```
+
 If you're a **Nix/NixOS** user, you can install xsv from nixpkgs:
 
 ```


### PR DESCRIPTION
Add instructions to install xsv from MacPorts, and use "macOS" uniformly in README.md.