### PR TITLE
Allow columns to be selected using regular expressions

### DIFF
--- a/tests/test_select.rs
+++ b/tests/test_select.rs
@@ -104,6 +104,11 @@ select_test!(select_range_no_end_cat, "h4-,h1", "4-,1",
 select_test!(select_range_no_start_cat, "-h2,h1[1]", "-2,5",
              ["h1", "h2", "h1"], ["a", "b", "e"]);
 
+select_test!(select_regex_double, r#"r"h[1-3]""#, "1,2,5",
+             ["h1", "h2", "h1"], ["a", "b", "e"]);
+select_test!(select_regex_single, r#"r'h[1-3]'"#, "1,2,5",
+             ["h1", "h2", "h1"], ["a", "b", "e"]);
+
 select_test_err!(select_err_unknown_header, "dne");
 select_test_err!(select_err_oob_low, "0");
 select_test_err!(select_err_oob_high, "6");


### PR DESCRIPTION
This allows a selector such as r'a[bc]?' to be used, which would
select columns 'a', 'ab', 'ac' but not 'ad'. This can be used in
the 'xsv select' command as well as anywhere that the '--select' flag
appears.

The interface is different to the one discussed in #155 because I couldn't think of an easy way to include the regex flag when `deserialize`ing the `SelectColumns`. It matches the regular expression string syntax from Python at the minute (i.e. prefixing a string with `r`), but it's a little ugly on the shell due to the need for two sets of strings :(

Here's some examples:

```
 ➜  xsv git:(155-select-column...) cat test.csv
a,ab,ac,ad,be,bf,bg
0,1,2,3,4,5,6
 ➜  xsv git:(155-select-column...) target/debug/xsv select r"'a[bc]'" test.csv
ab,ac
1,2
 ➜  xsv git:(155-select-column...) target/debug/xsv frequency -s "r'a[bc]?$'"  test.csv
field,value,count
a,0,1
ab,1,1
ac,2,1
```