### PR TITLE
Add support for building a snap via snapcraft

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,26 @@
+name: xsv
+version: git
+summary: "A fast CSV command line toolkit written in Rust"
+description: |
+  xsv is a command line program for indexing, slicing, analyzing, 
+  splitting and joining CSV files. Commands should be simple, 
+  fast and composable:
+    Simple tasks should be easy.
+    Performance trade offs should be exposed in the CLI interface.
+    Composition should not come at the expense of performance.
+
+
+grade: stable
+confinement: strict
+
+parts:
+  xsv:
+    plugin: rust
+    source: ./
+
+apps:
+  xsv:
+    command: bin/xsv
+    plugs:
+      - home
+      - removable-media


### PR DESCRIPTION
I created a snap package of xsv so it can be featured to the millions of Linux users installing apps from the [Snap Store](https://snapcraft.io/store). If you're willing to publish this under the xsv project name, you just need to [create an account](https://snapcraft.io/snaps) and then [register the xsv name](https://snapcraft.io/register-snap).

The snap file created by snapcraft can then be released in the Snap Store with snap push --release stable *.snap. You'll want to install snapcraft (brew install snapcraft, snap install snapcraft, or apt install snapcraft) and login (snapcraft login) first, though.

You may also want to consider using [https://build.snapcraft.io/](https://build.snapcraft.io/) which is a free build service, that can create armhf, amd64, i386, arm64 and other builds of xsv, and push them to the store automatically.

Thanks for making xsv! :)
