### PR TITLE
Fixed compiler warnings as directed by compiler hints.

### DIFF
--- a/src/cmd/headers.rs
+++ b/src/cmd/headers.rs
@@ -2,9 +2,9 @@ use std::io;
 
 use tabwriter::TabWriter;
 
-use CliResult;
 use config::Delimiter;
 use util;
+use CliResult;
 
 static USAGE: &'static str = "
 Prints the fields of the first row in the CSV data.
@@ -41,31 +41,27 @@ struct Args {
 
 pub fn run(argv: &[&str]) -> CliResult<()> {
     let args: Args = util::get_args(USAGE, argv)?;
-    let configs = util::many_configs(
-        &*args.arg_input, args.flag_delimiter, true)?;
+    let configs = util::many_configs(&*args.arg_input, args.flag_delimiter, true)?;
 
     let num_inputs = configs.len();
     let mut headers: Vec<Vec<u8>> = vec![];
     for conf in configs.into_iter() {
         let mut rdr = conf.reader()?;
         for header in rdr.byte_headers()?.iter() {
-            if !args.flag_intersect
-                || !headers.iter().any(|h| &**h == header)
-            {
+            if !args.flag_intersect || !headers.iter().any(|h| &**h == header) {
                 headers.push(header.to_vec());
             }
         }
     }
 
-    let mut wtr: Box<io::Write> =
-        if args.flag_just_names {
-            Box::new(io::stdout())
-        } else {
-            Box::new(TabWriter::new(io::stdout()))
-        };
+    let mut wtr: Box<dyn io::Write> = if args.flag_just_names {
+        Box::new(io::stdout())
+    } else {
+        Box::new(TabWriter::new(io::stdout()))
+    };
     for (i, header) in headers.into_iter().enumerate() {
         if num_inputs == 1 && !args.flag_just_names {
-            write!(&mut wtr, "{}\t", i+1)?;
+            write!(&mut wtr, "{}\t", i + 1)?;
         }
         wtr.write_all(&header)?;
         wtr.write_all(b"\n")?;

--- a/src/cmd/join.rs
+++ b/src/cmd/join.rs
@@ -278,7 +278,7 @@ impl<R: io::Read + io::Seek, W: io::Write> IoState<R, W> {
 
 impl Args {
     fn new_io_state(&self)
-        -> CliResult<IoState<fs::File, Box<io::Write+'static>>> {
+        -> CliResult<IoState<fs::File, Box<dyn io::Write+'static>>> {
         let rconf1 = Config::new(&Some(self.arg_input1.clone()))
             .delimiter(self.flag_delimiter)
             .no_headers(self.flag_no_headers)

--- a/src/cmd/partition.rs
+++ b/src/cmd/partition.rs
@@ -135,7 +135,7 @@ impl Args {
     }
 }
 
-type BoxedWriter = csv::Writer<Box<io::Write+'static>>;
+type BoxedWriter = csv::Writer<Box<dyn io::Write+'static>>;
 
 /// Generates unique filenames based on CSV values.
 struct WriterGenerator {

--- a/src/cmd/split.rs
+++ b/src/cmd/split.rs
@@ -128,7 +128,7 @@ impl Args {
         &self,
         headers: &csv::ByteRecord,
         start: usize,
-    ) -> CliResult<csv::Writer<Box<io::Write+'static>>> {
+    ) -> CliResult<csv::Writer<Box<dyn io::Write+'static>>> {
         let dir = Path::new(&self.arg_outdir);
         let path = dir.join(self.flag_filename.filename(&format!("{}", start)));
         let spath = Some(path.display().to_string());

--- a/src/config.rs
+++ b/src/config.rs
@@ -194,12 +194,12 @@ impl Config {
     }
 
     pub fn writer(&self)
-                 -> io::Result<csv::Writer<Box<io::Write+'static>>> {
+                 -> io::Result<csv::Writer<Box<dyn io::Write+'static>>> {
         Ok(self.from_writer(self.io_writer()?))
     }
 
     pub fn reader(&self)
-                 -> io::Result<csv::Reader<Box<io::Read+'static>>> {
+                 -> io::Result<csv::Reader<Box<dyn io::Read+'static>>> {
         Ok(self.from_reader(self.io_reader()?))
     }
 
@@ -260,7 +260,7 @@ impl Config {
         }
     }
 
-    pub fn io_reader(&self) -> io::Result<Box<io::Read+'static>> {
+    pub fn io_reader(&self) -> io::Result<Box<dyn io::Read+'static>> {
         Ok(match self.path {
                 None => Box::new(io::stdin()),
                 Some(ref p) => {
@@ -290,7 +290,7 @@ impl Config {
             .from_reader(rdr)
     }
 
-    pub fn io_writer(&self) -> io::Result<Box<io::Write+'static>> {
+    pub fn io_writer(&self) -> io::Result<Box<dyn io::Write+'static>> {
         Ok(match self.path {
             None => Box::new(io::stdout()),
             Some(ref p) => Box::new(fs::File::create(p)?),

--- a/src/util.rs
+++ b/src/util.rs
@@ -187,7 +187,7 @@ impl FilenameTemplate {
     /// that we do not output headers; the caller must do that if
     /// desired.
     pub fn writer<P>(&self, path: P, unique_value: &str)
-                 -> io::Result<csv::Writer<Box<io::Write+'static>>>
+                 -> io::Result<csv::Writer<Box<dyn io::Write+'static>>>
         where P: AsRef<Path>
     {
         let filename = self.filename(unique_value);

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -102,7 +102,7 @@ impl Arbitrary for CsvRecord {
         CsvRecord((0..size).map(|_| Arbitrary::arbitrary(g)).collect())
     }
 
-    fn shrink(&self) -> Box<Iterator<Item=CsvRecord>+'static> {
+    fn shrink(&self) -> Box<dyn Iterator<Item=CsvRecord>+'static> {
         Box::new(self.clone().unwrap()
                      .shrink().filter(|r| r.len() > 0).map(CsvRecord))
     }
@@ -148,7 +148,7 @@ impl Arbitrary for CsvData {
         }
     }
 
-    fn shrink(&self) -> Box<Iterator<Item=CsvData>+'static> {
+    fn shrink(&self) -> Box<dyn Iterator<Item=CsvData>+'static> {
         let len = if self.is_empty() { 0 } else { self[0].len() };
         let mut rows: Vec<CsvData> =
             self.clone()

--- a/tests/workdir.rs
+++ b/tests/workdir.rs
@@ -14,7 +14,7 @@ use Csv;
 
 static XSV_INTEGRATION_TEST_DIR: &'static str = "xit";
 
-static NEXT_ID: atomic::AtomicUsize = atomic::ATOMIC_USIZE_INIT;
+static NEXT_ID: atomic::AtomicUsize = atomic::AtomicUsize::new(0);
 
 pub struct Workdir {
     root: PathBuf,


### PR DESCRIPTION
cargo 1.38.0 (23ef9a4ef 2019-08-20)
rustc 1.38.0 (625451e37 2019-09-23)

Previously:

```
warning: trait objects without an explicit `dyn` are deprecated
  --> src/cmd/headers.rs:60:22
   |
60 |     let mut wtr: Box<io::Write> =
   |                      ^^^^^^^^^ help: use `dyn`: `dyn io::Write`
   |
   = note: `#[warn(bare_trait_objects)]` on by default

warning: trait objects without an explicit `dyn` are deprecated
   --> src/cmd/join.rs:281:44
    |
281 |         -> CliResult<IoState<fs::File, Box<io::Write+'static>>> {
    |                                            ^^^^^^^^^^^^^^^^^ help: use `dyn`: `dyn io::Write+'static`

warning: trait objects without an explicit `dyn` are deprecated
   --> src/cmd/partition.rs:138:36
    |
138 | type BoxedWriter = csv::Writer<Box<io::Write+'static>>;
    |                                    ^^^^^^^^^^^^^^^^^ help: use `dyn`: `dyn io::Write+'static`

warning: trait objects without an explicit `dyn` are deprecated
   --> src/cmd/split.rs:131:36
    |
131 |     ) -> CliResult<csv::Writer<Box<io::Write+'static>>> {
    |                                    ^^^^^^^^^^^^^^^^^ help: use `dyn`: `dyn io::Write+'static`

warning: trait objects without an explicit `dyn` are deprecated
   --> src/config.rs:197:48
    |
197 |                  -> io::Result<csv::Writer<Box<io::Write+'static>>> {
    |                                                ^^^^^^^^^^^^^^^^^ help: use `dyn`: `dyn io::Write+'static`

warning: trait objects without an explicit `dyn` are deprecated
   --> src/config.rs:202:48
    |
202 |                  -> io::Result<csv::Reader<Box<io::Read+'static>>> {
    |                                                ^^^^^^^^^^^^^^^^ help: use `dyn`: `dyn io::Read+'static`

warning: trait objects without an explicit `dyn` are deprecated
   --> src/config.rs:263:47
    |
263 |     pub fn io_reader(&self) -> io::Result<Box<io::Read+'static>> {
    |                                               ^^^^^^^^^^^^^^^^ help: use `dyn`: `dyn io::Read+'static`

warning: trait objects without an explicit `dyn` are deprecated
   --> src/config.rs:293:47
    |
293 |     pub fn io_writer(&self) -> io::Result<Box<io::Write+'static>> {
    |                                               ^^^^^^^^^^^^^^^^^ help: use `dyn`: `dyn io::Write+'static`

warning: trait objects without an explicit `dyn` are deprecated
   --> src/util.rs:190:48
    |
190 |                  -> io::Result<csv::Writer<Box<io::Write+'static>>>
    |                                                ^^^^^^^^^^^^^^^^^ help: use `dyn`: `dyn io::Write+'static`

warning: trait objects without an explicit `dyn` are deprecated
   --> tests/tests.rs:105:29
    |
105 |     fn shrink(&self) -> Box<Iterator<Item=CsvRecord>+'static> {
    |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `dyn`: `dyn Iterator<Item=CsvRecord>+'static`
    |
    = note: `#[warn(bare_trait_objects)]` on by default

warning: trait objects without an explicit `dyn` are deprecated
   --> tests/tests.rs:151:29
    |
151 |     fn shrink(&self) -> Box<Iterator<Item=CsvData>+'static> {
    |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `dyn`: `dyn Iterator<Item=CsvData>+'static`

warning: use of deprecated item 'std::sync::atomic::ATOMIC_USIZE_INIT': the `new` function is now preferred
  --> tests/workdir.rs:17:39
   |
17 | static NEXT_ID: atomic::AtomicUsize = atomic::ATOMIC_USIZE_INIT;
   |                                       ^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace the use of the deprecated item: `AtomicUsize::new(0)`
   |
   = note: `#[warn(deprecated)]` on by default

```