### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+#!/usr/bin/env -S docker build --compress -t xsv -f
+
+FROM debian:10 as build
+
+RUN apt update
+RUN apt install -y \
+	make cargo rustc
+
+WORKDIR /data
+COPY ./ ./
+
+RUN make -j$(nproc) release
+
+FROM debian:10
+COPY --from=build /data/target/release/xsv /usr/local/bin
+
+ENTRYPOINT [ "/usr/local/bin/xsv" ]
+CMD        [ "--help" ]


### PR DESCRIPTION
Adds `Dockerfile` for containerized environment

Provides:
- self building
- ci-like env
- multi-stage build
- reproducible builds

you can also do `./Dockerfile .` since I used shebang and execute bit on the file.

edit: I might use alpine but went with debian:10 as base image. Happy to change if needed