### PR TITLE
Add the -f/--flag <column> option to the search command

### DIFF
--- a/tests/test_search.rs
+++ b/tests/test_search.rs
@@ -149,3 +149,36 @@ fn search_invert_match_no_headers() {
     ];
     assert_eq!(got, expected);
 }
+
+#[test]
+fn search_flag() {
+    let wrk = Workdir::new("search_flag");
+    wrk.create("data.csv", data(false));
+    let mut cmd = wrk.command("search");
+    cmd.arg("^foo").arg("data.csv").args(&["--flag", "flagged"]);
+
+    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let expected = vec![
+        svec!["foobar", "barfoo", "flagged"],
+        svec!["a", "b", "0"],
+        svec!["barfoo", "foobar", "1"]
+    ];
+    assert_eq!(got, expected);
+}
+
+#[test]
+fn search_flag_invert_match() {
+    let wrk = Workdir::new("search_flag");
+    wrk.create("data.csv", data(false));
+    let mut cmd = wrk.command("search");
+    cmd.arg("^foo").arg("data.csv").args(&["--flag", "flagged"]);
+    cmd.arg("--invert-match");
+
+    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let expected = vec![
+        svec!["foobar", "barfoo", "flagged"],
+        svec!["a", "b", "1"],
+        svec!["barfoo", "foobar", "0"]
+    ];
+    assert_eq!(got, expected);
+}


### PR DESCRIPTION
Hello @BurntSushi,

Another PR to propose a `-f/--flag <column>` feature to the `search` command. If given, the command will not filter out rows that don't match but instead "flag" them as `0` or `1` in a new column appended to the row.

This is reminiscent of some [OpenRefine](https://openrefine.org/)'s workflows and can be useful in those two example cases:

If someone wants to partition the file on the result of a `search`:

```
xsv search "whatever" data.csv --flag p | xsv partition p
```

If someone wants to count the number of matches vs. non-matches easily:

```
xsv search "whatever" data.csv --flag matched | xsv frequency -s matched
```

Have a good day