### PR TITLE
Adding the `xsv behead` command that drop a CSV file's header

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Dual-licensed under MIT or the [UNLICENSE](https://unlicense.org).
 
 ### Available commands
 
+* **behead** - Drop headers from CSV file.
 * **cat** - Concatenate CSV files by row or by column.
 * **count** - Count the rows in a CSV file. (Instantaneous with an index.)
 * **fixlengths** - Force a CSV file to have same-length records by either

--- a/src/cmd/behead.rs
+++ b/src/cmd/behead.rs
@@ -1,0 +1,42 @@
+use csv;
+
+use CliResult;
+use config::{Delimiter, Config};
+use util;
+
+static USAGE: &'static str = "
+Drop a CSV file's header.
+
+Usage:
+    xsv behead [options] [<input>]
+
+Common options:
+    -h, --help             Display this message
+    -o, --output <file>    Write output to <file> instead of stdout.
+    -d, --delimiter <arg>  The field delimiter for reading CSV data.
+                           Must be a single character. (default: ,)
+";
+
+#[derive(Deserialize)]
+struct Args {
+    arg_input: Option<String>,
+    flag_delimiter: Option<Delimiter>,
+    flag_output: Option<String>,
+}
+
+pub fn run(argv: &[&str]) -> CliResult<()> {
+    let args: Args = util::get_args(USAGE, argv)?;
+    let conf = Config::new(&args.arg_input)
+        .delimiter(args.flag_delimiter)
+        .no_headers(false);
+
+    let mut rdr = conf.reader()?;
+    let mut wtr = Config::new(&args.flag_output).writer()?;
+    let mut record = csv::ByteRecord::new();
+
+    while rdr.read_byte_record(&mut record)? {
+        wtr.write_byte_record(&record)?;
+    }
+
+    Ok(wtr.flush()?)
+}

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -1,3 +1,4 @@
+pub mod behead;
 pub mod cat;
 pub mod count;
 pub mod fixlengths;

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,6 +43,7 @@ macro_rules! fail {
 macro_rules! command_list {
     () => (
 "
+    behead      Drop header from CSV file
     cat         Concatenate by row or column
     count       Count records
     fixlengths  Makes all records have same length
@@ -140,6 +141,7 @@ Please choose one of the following commands:",
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "lowercase")]
 enum Command {
+    Behead,
     Cat,
     Count,
     FixLengths,
@@ -171,10 +173,11 @@ impl Command {
 
         if !argv[1].chars().all(char::is_lowercase) {
             return Err(CliError::Other(format!(
-                "xsv expects commands in lowercase. Did you mean '{}'?", 
+                "xsv expects commands in lowercase. Did you mean '{}'?",
                 argv[1].to_lowercase()).to_string()));
         }
         match self {
+            Command::Behead => cmd::behead::run(argv),
             Command::Cat => cmd::cat::run(argv),
             Command::Count => cmd::count::run(argv),
             Command::FixLengths => cmd::fixlengths::run(argv),

--- a/tests/test_behead.rs
+++ b/tests/test_behead.rs
@@ -1,0 +1,20 @@
+use workdir::Workdir;
+
+#[test]
+fn behead() {
+    let wrk = Workdir::new("behead");
+    wrk.create("data.csv", vec![
+        svec!["letter", "number"],
+        svec!["a", "1"],
+        svec!["b", "2"],
+    ]);
+    let mut cmd = wrk.command("behead");
+    cmd.arg("data.csv");
+
+    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let expected = vec![
+        svec!["a", "1"],
+        svec!["b", "2"],
+    ];
+    assert_eq!(got, expected);
+}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -33,6 +33,7 @@ macro_rules! rassert_eq {
 
 mod workdir;
 
+mod test_behead;
 mod test_cat;
 mod test_count;
 mod test_fixlengths;


### PR DESCRIPTION
Hello again,

This PR adds a new command named `behead` and whose goal is to drop a CSV file's header. This is basically a glorified `tail -n +2` but has the advantage of being CSV-aware. I personally need this because I often work with CSV files given to me by mindless researchers that love having carriage returns in their column names.

Here is some cases when this command is useful:

* Sometimes, you need to drop a CSV header from a CSV file to conform to some other program or script that expects a headless CSV file.
* It can be quite useful in conjunction with `xsv select` so you can pipe to `xargs` or other unix tools that won't be expecting a header:

```
xsv select filepath files.csv | xsv behead | xargs -n 1 rm
```

Sorry for the gloomy command name. Must be my French atavism. I can of course change it if you have a better one in mind.