### PR TITLE
Adding the `xsv explode` command

### DIFF
--- a/src/cmd/explode.rs
+++ b/src/cmd/explode.rs
@@ -1,0 +1,95 @@
+use csv;
+
+use CliResult;
+use config::{Delimiter, Config};
+use select::SelectColumns;
+use util;
+
+static USAGE: &'static str = "
+Explodes a row into multiple ones by splitting a column value based on the
+given separator.
+
+For instance the following CSV:
+
+name,colors
+John,blue|yellow
+Mary,red
+
+Can be exploded on the \"colors\" <column> based on the \"|\" <separator> to:
+
+name,colors
+John,blue
+John,yellow
+Mary,red
+
+Usage:
+    xsv explode [options] <column> <separator> [<input>]
+
+explode options:
+    -r, --rename <name>    New name for the exploded column.
+
+Common options:
+    -h, --help             Display this message
+    -o, --output <file>    Write output to <file> instead of stdout.
+    -n, --no-headers       When set, the first row will not be interpreted
+                           as headers.
+    -d, --delimiter <arg>  The field delimiter for reading CSV data.
+                           Must be a single character. (default: ,)
+";
+
+#[derive(Deserialize)]
+struct Args {
+    arg_column: SelectColumns,
+    arg_separator: String,
+    arg_input: Option<String>,
+    flag_rename: Option<String>,
+    flag_output: Option<String>,
+    flag_no_headers: bool,
+    flag_delimiter: Option<Delimiter>,
+}
+
+pub fn replace_column_value(record: &csv::ByteRecord, column_index: usize, new_value: String)
+                           -> csv::ByteRecord {
+    record
+        .into_iter()
+        .enumerate()
+        .map(|(i, v)| if i == column_index { new_value.as_bytes() } else { v })
+        .collect()
+}
+
+pub fn run(argv: &[&str]) -> CliResult<()> {
+    let args: Args = util::get_args(USAGE, argv)?;
+    let rconfig = Config::new(&args.arg_input)
+        .delimiter(args.flag_delimiter)
+        .no_headers(args.flag_no_headers)
+        .select(args.arg_column);
+
+    let mut rdr = rconfig.reader()?;
+    let mut wtr = Config::new(&args.flag_output).writer()?;
+
+    let mut headers = rdr.byte_headers()?.clone();
+    let sel = rconfig.selection(&headers)?;
+    let column_index = *sel.iter().next().unwrap();
+
+    if let Some(new_name) = args.flag_rename {
+        headers = replace_column_value(&headers, column_index, new_name);
+    }
+
+    if !rconfig.no_headers {
+        wtr.write_record(&headers)?;
+    }
+
+    let mut record = csv::ByteRecord::new();
+
+    while rdr.read_byte_record(&mut record)? {
+        let values = String::from_utf8(record[column_index].to_vec())
+            .expect("Could not parse cell as utf-8!");
+
+        for val in values.split(&args.arg_separator) {
+            record = replace_column_value(&record, column_index, String::from(val));
+            wtr.write_byte_record(&record)?;
+        }
+    }
+
+    Ok(wtr.flush()?)
+}

--- a/src/cmd/explode.rs
+++ b/src/cmd/explode.rs
@@ -48,12 +48,12 @@ struct Args {
     flag_delimiter: Option<Delimiter>,
 }
 
-pub fn replace_column_value(record: &csv::ByteRecord, column_index: usize, new_value: String)
-                           -> csv::ByteRecord {
+pub fn replace_column_value(record: &csv::StringRecord, column_index: usize, new_value: &String)
+                           -> csv::StringRecord {
     record
         .into_iter()
         .enumerate()
-        .map(|(i, v)| if i == column_index { new_value.as_bytes() } else { v })
+        .map(|(i, v)| if i == column_index { new_value } else { v })
         .collect()
 }
 
@@ -67,27 +67,26 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
     let mut rdr = rconfig.reader()?;
     let mut wtr = Config::new(&args.flag_output).writer()?;
 
-    let mut headers = rdr.byte_headers()?.clone();
+    let headers = rdr.byte_headers()?.clone();
     let sel = rconfig.selection(&headers)?;
     let column_index = *sel.iter().next().unwrap();
 
+    let mut headers = rdr.headers()?.clone();
+
     if let Some(new_name) = args.flag_rename {
-        headers = replace_column_value(&headers, column_index, new_name);
+        headers = replace_column_value(&headers, column_index, &new_name);
     }
 
     if !rconfig.no_headers {
         wtr.write_record(&headers)?;
     }
 
-    let mut record = csv::ByteRecord::new();
+    let mut record = csv::StringRecord::new();
 
-    while rdr.read_byte_record(&mut record)? {
-        let values = String::from_utf8(record[column_index].to_vec())
-            .expect("Could not parse cell as utf-8!");
-
-        for val in values.split(&args.arg_separator) {
-            record = replace_column_value(&record, column_index, String::from(val));
-            wtr.write_byte_record(&record)?;
+    while rdr.read_record(&mut record)? {
+        for val in record[column_index].split(&args.arg_separator) {
+            let new_record = replace_column_value(&record, column_index, &val.to_owned());
+            wtr.write_record(&new_record)?;
         }
     }
 

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -1,5 +1,6 @@
 pub mod cat;
 pub mod count;
+pub mod explode;
 pub mod fixlengths;
 pub mod flatten;
 pub mod fmt;

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,6 +45,7 @@ macro_rules! command_list {
 "
     cat         Concatenate by row or column
     count       Count records
+    explode     Explode rows based on some column separator
     fixlengths  Makes all records have same length
     flatten     Show one field per line
     fmt         Format CSV output (change field delimiter)
@@ -142,6 +143,7 @@ Please choose one of the following commands:",
 enum Command {
     Cat,
     Count,
+    Explode,
     FixLengths,
     Flatten,
     Fmt,
@@ -171,12 +173,13 @@ impl Command {
 
         if !argv[1].chars().all(char::is_lowercase) {
             return Err(CliError::Other(format!(
-                "xsv expects commands in lowercase. Did you mean '{}'?", 
+                "xsv expects commands in lowercase. Did you mean '{}'?",
                 argv[1].to_lowercase()).to_string()));
         }
         match self {
             Command::Cat => cmd::cat::run(argv),
             Command::Count => cmd::count::run(argv),
+            Command::Explode => cmd::explode::run(argv),
             Command::FixLengths => cmd::fixlengths::run(argv),
             Command::Flatten => cmd::flatten::run(argv),
             Command::Fmt => cmd::fmt::run(argv),

--- a/tests/test_explode.rs
+++ b/tests/test_explode.rs
@@ -1,0 +1,68 @@
+use workdir::Workdir;
+
+#[test]
+fn explode() {
+    let wrk = Workdir::new("explode");
+    wrk.create("data.csv", vec![
+        svec!["name", "colors"],
+        svec!["Mary", "yellow"],
+        svec!["John", "blue|orange"],
+        svec!["Jack", ""],
+    ]);
+    let mut cmd = wrk.command("explode");
+    cmd.arg("colors").arg("|").arg("data.csv");
+
+    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let expected = vec![
+        svec!["name", "colors"],
+        svec!["Mary", "yellow"],
+        svec!["John", "blue"],
+        svec!["John", "orange"],
+        svec!["Jack", ""],
+    ];
+    assert_eq!(got, expected);
+}
+
+#[test]
+fn explode_rename() {
+    let wrk = Workdir::new("explode");
+    wrk.create("data.csv", vec![
+        svec!["name", "colors"],
+        svec!["Mary", "yellow"],
+        svec!["John", "blue|orange"],
+        svec!["Jack", ""],
+    ]);
+    let mut cmd = wrk.command("explode");
+    cmd.arg("colors").args(&["--rename", "color"]).arg("|").arg("data.csv");
+
+    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let expected = vec![
+        svec!["name", "color"],
+        svec!["Mary", "yellow"],
+        svec!["John", "blue"],
+        svec!["John", "orange"],
+        svec!["Jack", ""],
+    ];
+    assert_eq!(got, expected);
+}
+
+#[test]
+fn explode_no_headers() {
+    let wrk = Workdir::new("explode");
+    wrk.create("data.csv", vec![
+        svec!["Mary", "yellow"],
+        svec!["John", "blue|orange"],
+        svec!["Jack", ""],
+    ]);
+    let mut cmd = wrk.command("explode");
+    cmd.arg("2").arg("|").arg("--no-headers").arg("data.csv");
+
+    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let expected = vec![
+        svec!["Mary", "yellow"],
+        svec!["John", "blue"],
+        svec!["John", "orange"],
+        svec!["Jack", ""],
+    ];
+    assert_eq!(got, expected);
+}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -35,6 +35,7 @@ mod workdir;
 
 mod test_cat;
 mod test_count;
+mod test_explode;
 mod test_fixlengths;
 mod test_flatten;
 mod test_fmt;


### PR DESCRIPTION
Hello @BurntSushi,

This is my last PR for the day. Sorry for spamming. This one adds a command named `explode` (I chose `explode` to follow PHP's tradition since `split` was already taken) that is able to split a single rows into multiple ones by splitting a column's value using a given separator.

Basically it can transform the following file:

```csv
name,colors
John,blue|yellow
Mary,red
Jack,
```

into:

```csv
name,colors
John,blue
John,yellow
Mary,red
Jack,
```

using `xsv explode colors "|" data.csv`.

It comes with a `--rename` flag to rename the splitted column and supports the usual `--no-headers` flag.

It can be useful because a lot of people tend to avoid repetition thusly when handling not-fully tabular data using a somewhat inapropriate data format. Thus, by using this command, one can easily pipe it into `frequency` or `stats` and gather useful information nonetheless.

```
xsv explode colors "|" data.csv --rename color | xsv frequency -s color
```