### PR TITLE
Add --quote-never flag to fmt subcommand.

### DIFF
--- a/src/cmd/fmt.rs
+++ b/src/cmd/fmt.rs
@@ -23,6 +23,7 @@ fmt options:
     --ascii                    Use ASCII field and record separators.
     --quote <arg>              The quote character to use. [default: \"]
     --quote-always             Put quotes around every value.
+    --quote-never              Never put quotes around any value.
     --escape <arg>             The escape character to use. When not specified,
                                quotes are escaped by doubling them.
 
@@ -43,6 +44,7 @@ struct Args {
     flag_delimiter: Option<Delimiter>,
     flag_quote: Delimiter,
     flag_quote_always: bool,
+    flag_quote_never: bool,
     flag_escape: Option<Delimiter>,
 }
 
@@ -63,6 +65,8 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
     }
     if args.flag_quote_always {
         wconfig = wconfig.quote_style(csv::QuoteStyle::Always);
+    } else if args.flag_quote_never {
+        wconfig = wconfig.quote_style(csv::QuoteStyle::Never);
     }
     if let Some(escape) = args.flag_escape {
         wconfig = wconfig.escape(Some(escape.as_byte())).double_quote(false);

--- a/tests/test_fmt.rs
+++ b/tests/test_fmt.rs
@@ -7,6 +7,7 @@ fn setup(name: &str) -> (Workdir, process::Command) {
         svec!["h1", "h2"],
         svec!["abcdef", "ghijkl"],
         svec!["mnopqr", "stuvwx"],
+        svec!["ab\"cd\"ef", "gh,ij,kl"],
     ];
 
     let wrk = Workdir::new(name);
@@ -27,7 +28,8 @@ fn fmt_delimiter() {
     let expected = "\
 h1\th2
 abcdef\tghijkl
-mnopqr\tstuvwx";
+mnopqr\tstuvwx
+\"ab\"\"cd\"\"ef\"\tgh,ij,kl";
     assert_eq!(got, expected.to_string());
 }
 
@@ -40,7 +42,8 @@ fn fmt_weird_delimiter() {
     let expected = "\
 \"h1\"h\"h2\"
 abcdefh\"ghijkl\"
-mnopqrhstuvwx";
+mnopqrhstuvwx
+\"ab\"\"cd\"\"ef\"h\"gh,ij,kl\"";
     assert_eq!(got, expected.to_string());
 }
 
@@ -53,7 +56,8 @@ fn fmt_crlf() {
     let expected = "\
 h1,h2\r
 abcdef,ghijkl\r
-mnopqr,stuvwx";
+mnopqr,stuvwx\r
+\"ab\"\"cd\"\"ef\",\"gh,ij,kl\"";
     assert_eq!(got, expected.to_string());
 }
 
@@ -66,6 +70,21 @@ fn fmt_quote_always() {
     let expected = "\
 \"h1\",\"h2\"
 \"abcdef\",\"ghijkl\"
-\"mnopqr\",\"stuvwx\"";
+\"mnopqr\",\"stuvwx\"
+\"ab\"\"cd\"\"ef\",\"gh,ij,kl\"";
+    assert_eq!(got, expected.to_string());
+}
+
+#[test]
+fn fmt_quote_never() {
+    let (wrk, mut cmd) = setup("fmt_quote_never");
+    cmd.arg("--quote-never");
+
+    let got: String = wrk.stdout(&mut cmd);
+    let expected = "\
+h1,h2
+abcdef,ghijkl
+mnopqr,stuvwx
+ab\"cd\"ef,gh,ij,kl";
     assert_eq!(got, expected.to_string());
 }


### PR DESCRIPTION
Thank you @BurntSushi for this great tool! This PR should solve #107, I too needed to output some data without quotes.