### PR TITLE
Adding -u/--uniq flag to sort command

### DIFF
--- a/src/cmd/sort.rs
+++ b/src/cmd/sort.rs
@@ -104,7 +104,9 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
                         },
                     }
                 },
-                None => (),
+                None => {
+                    wtr.write_byte_record(&r)?;
+                },
             }
 
             prev = Some(r);

--- a/tests/test_sort.rs
+++ b/tests/test_sort.rs
@@ -128,6 +128,32 @@ fn sort_reverse() {
     assert_eq!(got, expected);
 }
 
+#[test]
+fn sort_uniq() {
+    let wrk = Workdir::new("sort_unique");
+    wrk.create("in.csv", vec![
+        svec!["number", "letter"],
+        svec!["2", "c"],
+        svec!["1", "a"],
+        svec!["3", "f"],
+        svec!["2", "b"],
+        svec!["1", "d"],
+        svec!["2", "e"],
+    ]);
+
+    let mut cmd = wrk.command("sort");
+    cmd.arg("-u").args(&["-s", "number"]).arg("-N").arg("in.csv");
+
+    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let expected = vec![
+        svec!["number", "letter"],
+        svec!["1", "a"],
+        svec!["2", "c"],
+        svec!["3", "f"],
+    ];
+    assert_eq!(got, expected);
+}
+
 /// Order `a` and `b` lexicographically using `Ord`
 pub fn iter_cmp<A, L, R>(mut a: L, mut b: R) -> cmp::Ordering
         where A: Ord, L: Iterator<Item=A>, R: Iterator<Item=A> {


### PR DESCRIPTION
Hello @BurntSushi,

Here is a simple PR to add a -u/--uniq flag to the xsv sort command that, if enabled, will drop identical consecutive lines in order to keep only one line per sorted value. It does not try to be clever about it by merging anything or else. This is often useful and is quite coherent with unix sort -u.

Have a good day

(Sorry this is a re-opening of a previous PR from a different branch, sorry for the notifications).