### PR TITLE
Adding the `xsv pseudo` command

### DIFF
--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -9,6 +9,7 @@ pub mod index;
 pub mod input;
 pub mod join;
 pub mod partition;
+pub mod pseudo;
 pub mod reverse;
 pub mod sample;
 pub mod search;

--- a/src/cmd/pseudo.rs
+++ b/src/cmd/pseudo.rs
@@ -1,0 +1,88 @@
+use std::collections::HashMap;
+
+use csv;
+
+use CliResult;
+use config::{Delimiter, Config};
+use select::SelectColumns;
+use util;
+
+static USAGE: &'static str = "
+Pseudonymise the value of the given column by replacing them by an
+incremental identifier.
+
+Usage:
+    xsv pseudo [options] <column> [<input>]
+    xsv pseudo --help
+
+Common options:
+    -h, --help             Display this message
+    -o, --output <file>    Write output to <file> instead of stdout.
+    -n, --no-headers       When set, the first row will not be interpreted
+                           as headers.
+    -d, --delimiter <arg>  The field delimiter for reading CSV data.
+                           Must be a single character. (default: ,)
+";
+
+#[derive(Deserialize)]
+struct Args {
+    arg_column: SelectColumns,
+    arg_input: Option<String>,
+    flag_output: Option<String>,
+    flag_no_headers: bool,
+    flag_delimiter: Option<Delimiter>,
+}
+
+pub fn replace_column_value(record: &csv::ByteRecord, column_index: usize, new_value: String)
+                           -> csv::ByteRecord {
+    record
+        .into_iter()
+        .enumerate()
+        .map(|(i, v)| if i == column_index { new_value.as_bytes() } else { v })
+        .collect()
+}
+
+type Values = HashMap<String, u64>;
+
+pub fn run(argv: &[&str]) -> CliResult<()> {
+    let args: Args = util::get_args(USAGE, argv)?;
+    let rconfig = Config::new(&args.arg_input)
+        .delimiter(args.flag_delimiter)
+        .no_headers(args.flag_no_headers)
+        .select(args.arg_column);
+
+    let mut rdr = rconfig.reader()?;
+    let mut wtr = Config::new(&args.flag_output).writer()?;
+
+    let headers = rdr.byte_headers()?.clone();
+    let sel = rconfig.selection(&headers)?;
+    let column_index = *sel.iter().next().unwrap();
+
+    if !rconfig.no_headers {
+        wtr.write_record(&headers)?;
+    }
+
+    let mut record = csv::ByteRecord::new();
+    let mut values = Values::new();
+    let mut counter: u64 = 0;
+
+    while rdr.read_byte_record(&mut record)? {
+        let value = String::from_utf8(record[column_index].to_vec())
+            .expect("Could not parse cell as utf-8!");
+
+        match values.get(&value) {
+          Some(id) => {
+            record = replace_column_value(&record, column_index, id.to_string());
+          },
+          None => {
+            values.insert(value, counter);
+            record = replace_column_value(&record, column_index, counter.to_string());
+            counter += 1;
+          }
+        }
+
+        wtr.write_byte_record(&record)?;
+    }
+
+    Ok(wtr.flush()?)
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -55,6 +55,7 @@ macro_rules! command_list {
     input       Read CSV data with special quoting rules
     join        Join CSV files
     partition   Partition CSV data based on a column value
+    pseudo      Pseudonymise the values of a column
     sample      Randomly sample CSV data
     reverse     Reverse rows of CSV data
     search      Search CSV data with regexes
@@ -152,6 +153,7 @@ enum Command {
     Input,
     Join,
     Partition,
+    Pseudo,
     Reverse,
     Sample,
     Search,
@@ -171,7 +173,7 @@ impl Command {
 
         if !argv[1].chars().all(char::is_lowercase) {
             return Err(CliError::Other(format!(
-                "xsv expects commands in lowercase. Did you mean '{}'?", 
+                "xsv expects commands in lowercase. Did you mean '{}'?",
                 argv[1].to_lowercase()).to_string()));
         }
         match self {
@@ -187,6 +189,7 @@ impl Command {
             Command::Input => cmd::input::run(argv),
             Command::Join => cmd::join::run(argv),
             Command::Partition => cmd::partition::run(argv),
+            Command::Pseudo => cmd::pseudo::run(argv),
             Command::Reverse => cmd::reverse::run(argv),
             Command::Sample => cmd::sample::run(argv),
             Command::Search => cmd::search::run(argv),

--- a/tests/test_pseudo.rs
+++ b/tests/test_pseudo.rs
@@ -1,0 +1,55 @@
+use workdir::Workdir;
+
+#[test]
+fn pseudo() {
+    let wrk = Workdir::new("pseudo");
+    wrk.create("data.csv", vec![
+        svec!["name", "colors"],
+        svec!["Mary", "yellow"],
+        svec!["John", "blue"],
+        svec!["Mary", "purple"],
+        svec!["Sue", "orange"],
+        svec!["John", "magenta"],
+        svec!["Mary", "cyan"],
+    ]);
+    let mut cmd = wrk.command("pseudo");
+    cmd.arg("name").arg("data.csv");
+
+    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let expected = vec![
+        svec!["name", "colors"],
+        svec!["0", "yellow"],
+        svec!["1", "blue"],
+        svec!["0", "purple"],
+        svec!["2", "orange"],
+        svec!["1", "magenta"],
+        svec!["0", "cyan"],
+    ];
+    assert_eq!(got, expected);
+}
+
+#[test]
+fn pseudo_no_headers() {
+    let wrk = Workdir::new("pseudo");
+    wrk.create("data.csv", vec![
+        svec!["Mary", "yellow"],
+        svec!["John", "blue"],
+        svec!["Mary", "purple"],
+        svec!["Sue", "orange"],
+        svec!["John", "magenta"],
+        svec!["Mary", "cyan"],
+    ]);
+    let mut cmd = wrk.command("pseudo");
+    cmd.arg("1").arg("--no-headers").arg("data.csv");
+
+    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let expected = vec![
+        svec!["0", "yellow"],
+        svec!["1", "blue"],
+        svec!["0", "purple"],
+        svec!["2", "orange"],
+        svec!["1", "magenta"],
+        svec!["0", "cyan"],
+    ];
+    assert_eq!(got, expected);
+}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -43,6 +43,7 @@ mod test_headers;
 mod test_index;
 mod test_join;
 mod test_partition;
+mod test_pseudo;
 mod test_reverse;
 mod test_search;
 mod test_select;


### PR DESCRIPTION
Hello @BurntSushi,

Just a PR to add a `xsv pseudo <column>` command that can pseudonymise a column's value by replacing them by an incremental id.

I don't propose that this should be added to the tool but I just offer this to the community if it can help anyone. What's more I haven't tried to be particularly efficient with this as I only used std's hashmap and this can be quite memory-hungry based on the cardinality of the column.

Anyway, I wish you a good day (or evening, or whatever),