### PR TITLE
Adding the `xsv replace` command

### DIFF
--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -9,6 +9,7 @@ pub mod index;
 pub mod input;
 pub mod join;
 pub mod partition;
+pub mod replace;
 pub mod reverse;
 pub mod sample;
 pub mod search;

--- a/src/cmd/replace.rs
+++ b/src/cmd/replace.rs
@@ -1,0 +1,88 @@
+use csv;
+use regex::bytes::RegexBuilder;
+use std::borrow::Cow;
+
+use CliResult;
+use config::{Config, Delimiter};
+use select::SelectColumns;
+use util;
+
+static USAGE: &'static str = "
+Replace occurrences of a pattern across a CSV file.
+
+You can of course match groups using parentheses and use those in
+the replacement string. But don't forget to escape your $ in bash by using a
+backslash or by wrapping the replacement string into single quotes:
+
+  $ xsv replace 'hel(lo)' 'hal$1' file.csv
+  $ xsv replace \"hel(lo)\" \"hal\\$1\" file.csv
+
+Usage:
+    xsv replace [options] <pattern> <replacement> [<input>]
+    xsv replace --help
+
+replace options:
+    -i, --ignore-case      Case insensitive search. This is equivalent to
+                           prefixing the regex with '(?i)'.
+    -s, --select <arg>     Select the columns to search. See 'xsv select -h'
+                           for the full syntax.
+
+Common options:
+    -h, --help             Display this message
+    -o, --output <file>    Write output to <file> instead of stdout.
+    -n, --no-headers       When set, the first row will not be interpreted
+                           as headers. (i.e., They are not searched, analyzed,
+                           sliced, etc.)
+    -d, --delimiter <arg>  The field delimiter for reading CSV data.
+                           Must be a single character. (default: ,)
+";
+
+#[derive(Deserialize)]
+struct Args {
+    arg_input: Option<String>,
+    arg_pattern: String,
+    arg_replacement: String,
+    flag_select: SelectColumns,
+    flag_output: Option<String>,
+    flag_no_headers: bool,
+    flag_delimiter: Option<Delimiter>,
+    flag_ignore_case: bool,
+}
+
+pub fn run(argv: &[&str]) -> CliResult<()> {
+    let args: Args = util::get_args(USAGE, argv)?;
+    let pattern = RegexBuilder::new(&*args.arg_pattern)
+        .case_insensitive(args.flag_ignore_case)
+        .build()?;
+    let replacement = args.arg_replacement.as_bytes();
+    let rconfig = Config::new(&args.arg_input)
+        .delimiter(args.flag_delimiter)
+        .no_headers(args.flag_no_headers)
+        .select(args.flag_select);
+
+    let mut rdr = rconfig.reader()?;
+    let mut wtr = Config::new(&args.flag_output).writer()?;
+
+    let headers = rdr.byte_headers()?.clone();
+    let sel = rconfig.selection(&headers)?;
+
+    // NOTE: using vec lookups is not the fastest thing in the world but
+    // I am not sure it would be worthwhile to rely on a set structure
+    let sel_indices = sel.to_vec();
+
+    if !rconfig.no_headers {
+        wtr.write_record(&headers)?;
+    }
+    let mut record = csv::ByteRecord::new();
+
+    while rdr.read_byte_record(&mut record)? {
+        record = record
+            .into_iter()
+            .enumerate()
+            .map(|(i, v)| if sel_indices.contains(&i) { pattern.replace_all(v, replacement) } else { Cow::Borrowed(v) })
+            .collect();
+
+        wtr.write_byte_record(&record)?;
+    }
+    Ok(wtr.flush()?)
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -56,6 +56,7 @@ macro_rules! command_list {
     join        Join CSV files
     partition   Partition CSV data based on a column value
     sample      Randomly sample CSV data
+    replace     Replace patterns in CSV data
     reverse     Reverse rows of CSV data
     search      Search CSV data with regexes
     select      Select columns from CSV
@@ -152,6 +153,7 @@ enum Command {
     Input,
     Join,
     Partition,
+    Replace,
     Reverse,
     Sample,
     Search,
@@ -171,7 +173,7 @@ impl Command {
 
         if !argv[1].chars().all(char::is_lowercase) {
             return Err(CliError::Other(format!(
-                "xsv expects commands in lowercase. Did you mean '{}'?", 
+                "xsv expects commands in lowercase. Did you mean '{}'?",
                 argv[1].to_lowercase()).to_string()));
         }
         match self {
@@ -187,6 +189,7 @@ impl Command {
             Command::Input => cmd::input::run(argv),
             Command::Join => cmd::join::run(argv),
             Command::Partition => cmd::partition::run(argv),
+            Command::Replace => cmd::replace::run(argv),
             Command::Reverse => cmd::reverse::run(argv),
             Command::Sample => cmd::sample::run(argv),
             Command::Search => cmd::search::run(argv),

--- a/tests/test_replace.rs
+++ b/tests/test_replace.rs
@@ -1,0 +1,95 @@
+use workdir::Workdir;
+
+#[test]
+fn replace() {
+    let wrk = Workdir::new("replace");
+    wrk.create("data.csv", vec![
+        svec!["identifier", "color"],
+        svec!["164.0", "yellow"],
+        svec!["165.0", "yellow"],
+        svec!["166.0", "yellow"],
+        svec!["167.0", "yellow.0"],
+    ]);
+    let mut cmd = wrk.command("replace");
+    cmd.arg("\\.0$").arg("").arg("data.csv");
+
+    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let expected = vec![
+      svec!["identifier", "color"],
+      svec!["164", "yellow"],
+      svec!["165", "yellow"],
+      svec!["166", "yellow"],
+      svec!["167", "yellow"],
+    ];
+    assert_eq!(got, expected);
+}
+
+#[test]
+fn replace_no_headers() {
+  let wrk = Workdir::new("replace");
+  wrk.create("data.csv", vec![
+      svec!["164.0", "yellow"],
+      svec!["165.0", "yellow"],
+      svec!["166.0", "yellow"],
+      svec!["167.0", "yellow.0"],
+  ]);
+  let mut cmd = wrk.command("replace");
+  cmd.arg("\\.0$").arg("").arg("--no-headers").arg("--select").arg("1").arg("data.csv");
+
+  let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+  let expected = vec![
+    svec!["164", "yellow"],
+    svec!["165", "yellow"],
+    svec!["166", "yellow"],
+    svec!["167", "yellow.0"],
+  ];
+  assert_eq!(got, expected);
+}
+
+#[test]
+fn replace_select() {
+    let wrk = Workdir::new("replace");
+    wrk.create("data.csv", vec![
+        svec!["identifier", "color"],
+        svec!["164.0", "yellow"],
+        svec!["165.0", "yellow"],
+        svec!["166.0", "yellow"],
+        svec!["167.0", "yellow.0"],
+    ]);
+    let mut cmd = wrk.command("replace");
+    cmd.arg("\\.0$").arg("").arg("--select").arg("identifier").arg("data.csv");
+
+    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let expected = vec![
+      svec!["identifier", "color"],
+      svec!["164", "yellow"],
+      svec!["165", "yellow"],
+      svec!["166", "yellow"],
+      svec!["167", "yellow.0"],
+    ];
+    assert_eq!(got, expected);
+}
+
+#[test]
+fn replace_groups() {
+  let wrk = Workdir::new("replace");
+  wrk.create("data.csv", vec![
+      svec!["identifier", "color"],
+      svec!["164.0", "yellow"],
+      svec!["165.0", "yellow"],
+      svec!["166.0", "yellow"],
+      svec!["167.0", "yellow.0"],
+  ]);
+  let mut cmd = wrk.command("replace");
+  cmd.arg("\\d+(\\d)\\.0$").arg("$1").arg("--select").arg("identifier").arg("data.csv");
+
+  let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+  let expected = vec![
+    svec!["identifier", "color"],
+    svec!["4", "yellow"],
+    svec!["5", "yellow"],
+    svec!["6", "yellow"],
+    svec!["7", "yellow.0"],
+  ];
+  assert_eq!(got, expected);
+}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -43,6 +43,7 @@ mod test_headers;
 mod test_index;
 mod test_join;
 mod test_partition;
+mod test_replace;
 mod test_reverse;
 mod test_search;
 mod test_select;


### PR DESCRIPTION
Hello @BurntSushi,

A PR adding a `replace` command to xsv and which is quite similar to `search` but that will replace all the occurrences of the found pattern across the selected column values. I chose to split it into a separate command instead of adding a flag to the `search` command not to muddle the tool's semantics and to avoid conflicts with the `--invert-match` for instance.

Have a good day,