### PR TITLE
Adding the `xsv enumerate` command

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ serde_derive = "1"
 streaming-stats = "0.2"
 tabwriter = "1"
 threadpool = "1.3"
+uuid = { version = "0.8.1", features = ["v4"] }
 
 [dev-dependencies]
 quickcheck = { version = "0.7", default-features = false }

--- a/src/cmd/enumerate.rs
+++ b/src/cmd/enumerate.rs
@@ -11,29 +11,29 @@ Add a new column enumerating the lines of a CSV file. This can be useful to keep
 track of a specific line order, give a unique identifier to each line or even
 make a copy of the contents of a column.
 
-The enumerate function can currently be used to perform the following tasks:
+The enum function can currently be used to perform the following tasks:
 
   Add an incremental identifier to each of the lines:
-    $ xsv enumerate file.csv
+    $ xsv enum file.csv
 
   Add a uuid v4 to each of the lines:
-    $ xsv enumerate --uuid file.csv
+    $ xsv enum --uuid file.csv
 
   Create a new column filled with a given value:
-    $ xsv enumerate --constant 0
+    $ xsv enum --constant 0
 
   Copy the contents of a column to a new one:
-    $ xsv enumerate --copy names
+    $ xsv enum --copy names
 
   Finally, note that you should also be able to shuffle the lines of a CSV file
   by sorting on the generated uuids:
-    $ xsv enumerate uuid file.csv | xsv sort -s uuid > shuffled.csv
+    $ xsv enum uuid file.csv | xsv sort -s uuid > shuffled.csv
 
 Usage:
-    xsv enumerate [options] [<input>]
-    xsv enumerate --help
+    xsv enum [options] [<input>]
+    xsv enum --help
 
-enumerate options:
+enum options:
     -c, --new-column <name>  Name of the column to create.
                              Will default to "index".
     --constant <value>       Fill a new column with the given value.

--- a/src/cmd/enumerate.rs
+++ b/src/cmd/enumerate.rs
@@ -83,7 +83,9 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
             headers.push_field(b"constant");
         }
         else if copy_operation {
-            headers.push_field(format!("{}_copy", String::from_utf8(headers[copy_index].to_vec()).expect("Could not parse cell as utf-8!")).as_bytes());
+            let current_header = String::from_utf8(headers[copy_index].to_vec())
+                .expect("Could not parse cell as utf-8!");
+            headers.push_field(format!("{}_copy", current_header).as_bytes());
         }
         else {
             headers.push_field(b"index");
@@ -100,8 +102,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
             record.push_field(constant_value.as_bytes());
         }
         else if copy_operation {
-            let cell = String::from_utf8(record[copy_index].to_vec()).expect("Could not parse cell as utf-8!");
-            record.push_field(cell.as_bytes());
+            record.push_field(&record[copy_index].to_vec());
         }
         else if args.flag_uuid {
             let id = Uuid::new_v4();

--- a/src/cmd/enumerate.rs
+++ b/src/cmd/enumerate.rs
@@ -21,9 +21,11 @@ Usage:
 enumerate options:
     -c, --new-column <name>  Name of the column to create.
                              Will default to \"index\".
+    --constant <value>       Fill a new column with the given value.
+                             Changes the default column name to \"constant\".
     --uuid                   When set, the column will be populated with
                              uuids (v4) instead of the incremental identifer.
-                             Also changes the default column name to \"uuid\".
+                             Changes the default column name to \"uuid\".
 
 Common options:
     -h, --help               Display this message
@@ -38,6 +40,7 @@ Common options:
 struct Args {
     arg_input: Option<String>,
     flag_new_column: Option<String>,
+    flag_constant: Option<String>,
     flag_uuid: bool,
     flag_output: Option<String>,
     flag_no_headers: bool,
@@ -70,7 +73,10 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
     let mut counter: u64 = 0;
 
     while rdr.read_byte_record(&mut record)? {
-        if args.flag_uuid {
+        if let Some(constant_value) = &args.flag_constant {
+            record.push_field(constant_value.as_bytes());
+        }
+        else if args.flag_uuid {
             let id = Uuid::new_v4();
             record.push_field(id.to_hyphenated().encode_lower(&mut Uuid::encode_buffer()).as_bytes());
         }

--- a/src/cmd/enumerate.rs
+++ b/src/cmd/enumerate.rs
@@ -7,13 +7,27 @@ use config::{Delimiter, Config};
 use util;
 
 static USAGE: &'static str = r#"
-Add a new column enumerating the lines of a CSV file. This is useful to keep
-track of a specific line order or give a unique identifier to each line.
+Add a new column enumerating the lines of a CSV file. This can be useful to keep
+track of a specific line order, give a unique identifier to each line or even
+make a copy of the contents of a column.
 
-You should also be able to shuffle the lines of a CSV file by sorting on
-the generated uuids:
+The enumerate function can currently be used to perform the following tasks:
 
-  $ xsv enumerate uuid file.csv | xsv sort -s uuid > shuffled.csv
+  Add an incremental identifier to each of the lines:
+    $ xsv enumerate file.csv
+
+  Add a uuid v4 to each of the lines:
+    $ xsv enumerate --uuid file.csv
+
+  Create a new column filled with a given value:
+    $ xsv enumerate --constant 0
+
+  Copy the contents of a column to a new one:
+    $ xsv enumerate --copy names
+
+  Finally, note that you should also be able to shuffle the lines of a CSV file
+  by sorting on the generated uuids:
+    $ xsv enumerate uuid file.csv | xsv sort -s uuid > shuffled.csv
 
 Usage:
     xsv enumerate [options] [<input>]

--- a/src/cmd/enumerate.rs
+++ b/src/cmd/enumerate.rs
@@ -9,6 +9,11 @@ static USAGE: &'static str = "
 Add a new column enumerating the lines of a CSV file. This is useful to keep
 track of a specific line order or give a unique identifier to each line.
 
+You should also be able to shuffle the lines of a CSV file by sorting on
+the generated uuids:
+
+  $ xsv enumerate uuid file.csv | xsv sort -s uuid > shuffled.csv
+
 Usage:
     xsv enumerate [options] [<input>]
     xsv enumerate --help

--- a/src/cmd/enumerate.rs
+++ b/src/cmd/enumerate.rs
@@ -19,25 +19,25 @@ Usage:
     xsv enumerate --help
 
 enumerate options:
-    --column-name <arg>    Name of the column to create.
-                           Will default to \"index\".
-    --uuid                 When set, the column will be populated with
-                           uuids (v4) instead of the incremental identifer.
-                           Also change the default column name to \"uuid\".
+    -c, --new-column <name>  Name of the column to create.
+                             Will default to \"index\".
+    --uuid                   When set, the column will be populated with
+                             uuids (v4) instead of the incremental identifer.
+                             Also changes the default column name to \"uuid\".
 
 Common options:
-    -h, --help             Display this message
-    -o, --output <file>    Write output to <file> instead of stdout.
-    -n, --no-headers       When set, the first row will not be interpreted
-                           as headers.
-    -d, --delimiter <arg>  The field delimiter for reading CSV data.
-                           Must be a single character. (default: ,)
+    -h, --help               Display this message
+    -o, --output <file>      Write output to <file> instead of stdout.
+    -n, --no-headers         When set, the first row will not be interpreted
+                             as headers.
+    -d, --delimiter <arg>    The field delimiter for reading CSV data.
+                             Must be a single character. (default: ,)
 ";
 
 #[derive(Deserialize)]
 struct Args {
     arg_input: Option<String>,
-    flag_column_name: Option<String>,
+    flag_new_column: Option<String>,
     flag_uuid: bool,
     flag_output: Option<String>,
     flag_no_headers: bool,
@@ -55,7 +55,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
 
     let mut headers = rdr.byte_headers()?.clone();
 
-    let new_column_name = match (&args.flag_column_name, args.flag_uuid) {
+    let new_column_name = match (&args.flag_new_column, args.flag_uuid) {
         (Some(column_name), _) => column_name.as_bytes(),
         (None, false) => b"index",
         (None, true) => b"uuid"

--- a/src/cmd/enumerate.rs
+++ b/src/cmd/enumerate.rs
@@ -1,0 +1,80 @@
+use csv;
+use uuid::Uuid;
+
+use CliResult;
+use config::{Delimiter, Config};
+use util;
+
+static USAGE: &'static str = "
+Add a new column enumerating the lines of a CSV file. This is useful to keep
+track of a specific line order or give a unique identifier to each line.
+
+Usage:
+    xsv enumerate [options] [<input>]
+    xsv enumerate --help
+
+enumerate options:
+    --column-name <arg>    Name of the column to create.
+                           Will default to \"index\".
+    --uuid                 When set, the column will be populated with
+                           uuids (v4) instead of the incremental identifer.
+                           Also change the default column name to \"uuid\".
+
+Common options:
+    -h, --help             Display this message
+    -o, --output <file>    Write output to <file> instead of stdout.
+    -n, --no-headers       When set, the first row will not be interpreted
+                           as headers.
+    -d, --delimiter <arg>  The field delimiter for reading CSV data.
+                           Must be a single character. (default: ,)
+";
+
+#[derive(Deserialize)]
+struct Args {
+    arg_input: Option<String>,
+    flag_column_name: Option<String>,
+    flag_uuid: bool,
+    flag_output: Option<String>,
+    flag_no_headers: bool,
+    flag_delimiter: Option<Delimiter>,
+}
+
+pub fn run(argv: &[&str]) -> CliResult<()> {
+    let args: Args = util::get_args(USAGE, argv)?;
+    let rconfig = Config::new(&args.arg_input)
+        .delimiter(args.flag_delimiter)
+        .no_headers(args.flag_no_headers);
+
+    let mut rdr = rconfig.reader()?;
+    let mut wtr = Config::new(&args.flag_output).writer()?;
+
+    let mut headers = rdr.byte_headers()?.clone();
+
+    let new_column_name = match (&args.flag_column_name, args.flag_uuid) {
+        (Some(column_name), _) => column_name.as_bytes(),
+        (None, false) => b"index",
+        (None, true) => b"uuid"
+    };
+
+    if !rconfig.no_headers {
+        headers.push_field(new_column_name);
+        wtr.write_record(&headers)?;
+    }
+
+    let mut record = csv::ByteRecord::new();
+    let mut counter: u64 = 0;
+
+    while rdr.read_byte_record(&mut record)? {
+        if args.flag_uuid {
+            let id = Uuid::new_v4();
+            record.push_field(id.to_hyphenated().encode_lower(&mut Uuid::encode_buffer()).as_bytes());
+        }
+        else {
+            record.push_field(counter.to_string().as_bytes());
+            counter += 1;
+        }
+        wtr.write_byte_record(&record)?;
+    }
+
+    Ok(wtr.flush()?)
+}

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -1,5 +1,6 @@
 pub mod cat;
 pub mod count;
+pub mod enumerate;
 pub mod fixlengths;
 pub mod flatten;
 pub mod fmt;

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,7 +46,7 @@ macro_rules! command_list {
 "
     cat         Concatenate by row or column
     count       Count records
-    enumerate   Add a column enumerating CSV lines
+    enum        Add a new column enumerating CSV lines
     fixlengths  Makes all records have same length
     flatten     Show one field per line
     fmt         Format CSV output (change field delimiter)
@@ -144,7 +144,7 @@ Please choose one of the following commands:",
 enum Command {
     Cat,
     Count,
-    Enumerate,
+    Enum,
     FixLengths,
     Flatten,
     Fmt,
@@ -180,7 +180,7 @@ impl Command {
         match self {
             Command::Cat => cmd::cat::run(argv),
             Command::Count => cmd::count::run(argv),
-            Command::Enumerate => cmd::enumerate::run(argv),
+            Command::Enum => cmd::enumerate::run(argv),
             Command::FixLengths => cmd::fixlengths::run(argv),
             Command::Flatten => cmd::flatten::run(argv),
             Command::Fmt => cmd::fmt::run(argv),

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,7 @@ extern crate serde_derive;
 extern crate stats;
 extern crate tabwriter;
 extern crate threadpool;
+extern crate uuid;
 
 use std::borrow::ToOwned;
 use std::env;
@@ -45,6 +46,7 @@ macro_rules! command_list {
 "
     cat         Concatenate by row or column
     count       Count records
+    enumerate   Add a column enumerating CSV lines
     fixlengths  Makes all records have same length
     flatten     Show one field per line
     fmt         Format CSV output (change field delimiter)
@@ -142,6 +144,7 @@ Please choose one of the following commands:",
 enum Command {
     Cat,
     Count,
+    Enumerate,
     FixLengths,
     Flatten,
     Fmt,
@@ -171,12 +174,13 @@ impl Command {
 
         if !argv[1].chars().all(char::is_lowercase) {
             return Err(CliError::Other(format!(
-                "xsv expects commands in lowercase. Did you mean '{}'?", 
+                "xsv expects commands in lowercase. Did you mean '{}'?",
                 argv[1].to_lowercase()).to_string()));
         }
         match self {
             Command::Cat => cmd::cat::run(argv),
             Command::Count => cmd::count::run(argv),
+            Command::Enumerate => cmd::enumerate::run(argv),
             Command::FixLengths => cmd::fixlengths::run(argv),
             Command::Flatten => cmd::flatten::run(argv),
             Command::Fmt => cmd::fmt::run(argv),

--- a/tests/test_enumerate.rs
+++ b/tests/test_enumerate.rs
@@ -48,3 +48,26 @@ fn enumerate_column_name() {
     assert_eq!(got, expected);
 }
 
+#[test]
+fn enumerate_constants() {
+    let wrk = Workdir::new("enumerate");
+    wrk.create("data.csv", vec![
+        svec!["letter", "number"],
+        svec!["a", "13"],
+        svec!["b", "24"],
+        svec!["c", "72"],
+        svec!["d", "7"],
+    ]);
+    let mut cmd = wrk.command("enumerate");
+    cmd.arg("-c").arg("val").arg("--constant").arg("test").arg("data.csv");
+
+    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let expected = vec![
+        svec!["letter", "number", "val"],
+        svec!["a", "13", "test"],
+        svec!["b", "24", "test"],
+        svec!["c", "72", "test"],
+        svec!["d", "7", "test"],
+    ];
+    assert_eq!(got, expected);
+}

--- a/tests/test_enumerate.rs
+++ b/tests/test_enumerate.rs
@@ -1,0 +1,50 @@
+use workdir::Workdir;
+
+#[test]
+fn enumerate() {
+    let wrk = Workdir::new("enumerate");
+    wrk.create("data.csv", vec![
+        svec!["letter", "number"],
+        svec!["a", "13"],
+        svec!["b", "24"],
+        svec!["c", "72"],
+        svec!["d", "7"],
+    ]);
+    let mut cmd = wrk.command("enumerate");
+    cmd.arg("data.csv");
+
+    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let expected = vec![
+        svec!["letter", "number", "index"],
+        svec!["a", "13", "0"],
+        svec!["b", "24", "1"],
+        svec!["c", "72", "2"],
+        svec!["d", "7", "3"],
+    ];
+    assert_eq!(got, expected);
+}
+
+#[test]
+fn enumerate_column_name() {
+    let wrk = Workdir::new("enumerate");
+    wrk.create("data.csv", vec![
+        svec!["letter", "number"],
+        svec!["a", "13"],
+        svec!["b", "24"],
+        svec!["c", "72"],
+        svec!["d", "7"],
+    ]);
+    let mut cmd = wrk.command("enumerate");
+    cmd.arg("--column-name").arg("row").arg("data.csv");
+
+    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let expected = vec![
+        svec!["letter", "number", "row"],
+        svec!["a", "13", "0"],
+        svec!["b", "24", "1"],
+        svec!["c", "72", "2"],
+        svec!["d", "7", "3"],
+    ];
+    assert_eq!(got, expected);
+}
+

--- a/tests/test_enumerate.rs
+++ b/tests/test_enumerate.rs
@@ -49,7 +49,7 @@ fn enumerate_column_name() {
 }
 
 #[test]
-fn enumerate_constants() {
+fn enumerate_constant() {
     let wrk = Workdir::new("enumerate");
     wrk.create("data.csv", vec![
         svec!["letter", "number"],
@@ -59,15 +59,63 @@ fn enumerate_constants() {
         svec!["d", "7"],
     ]);
     let mut cmd = wrk.command("enumerate");
-    cmd.arg("-c").arg("val").arg("--constant").arg("test").arg("data.csv");
+    cmd.arg("--constant").arg("test").arg("data.csv");
 
     let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
     let expected = vec![
-        svec!["letter", "number", "val"],
+        svec!["letter", "number", "constant"],
         svec!["a", "13", "test"],
         svec!["b", "24", "test"],
         svec!["c", "72", "test"],
         svec!["d", "7", "test"],
+    ];
+    assert_eq!(got, expected);
+}
+
+#[test]
+fn enumerate_copy() {
+    let wrk = Workdir::new("enumerate");
+    wrk.create("data.csv", vec![
+        svec!["letter", "number"],
+        svec!["a", "13"],
+        svec!["b", "24"],
+        svec!["c", "72"],
+        svec!["d", "7"],
+    ]);
+    let mut cmd = wrk.command("enumerate");
+    cmd.arg("--copy").arg("number").arg("data.csv");
+
+    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let expected = vec![
+        svec!["letter", "number", "number_copy"],
+        svec!["a", "13", "13"],
+        svec!["b", "24", "24"],
+        svec!["c", "72", "72"],
+        svec!["d", "7", "7"],
+    ];
+    assert_eq!(got, expected);
+}
+
+#[test]
+fn enumerate_copy_name() {
+    let wrk = Workdir::new("enumerate");
+    wrk.create("data.csv", vec![
+        svec!["letter", "number"],
+        svec!["a", "13"],
+        svec!["b", "24"],
+        svec!["c", "72"],
+        svec!["d", "7"],
+    ]);
+    let mut cmd = wrk.command("enumerate");
+    cmd.arg("--copy").arg("number").arg("-c").arg("chiffre").arg("data.csv");
+
+    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let expected = vec![
+        svec!["letter", "number", "chiffre"],
+        svec!["a", "13", "13"],
+        svec!["b", "24", "24"],
+        svec!["c", "72", "72"],
+        svec!["d", "7", "7"],
     ];
     assert_eq!(got, expected);
 }

--- a/tests/test_enumerate.rs
+++ b/tests/test_enumerate.rs
@@ -2,7 +2,7 @@ use workdir::Workdir;
 
 #[test]
 fn enumerate() {
-    let wrk = Workdir::new("enumerate");
+    let wrk = Workdir::new("enum");
     wrk.create("data.csv", vec![
         svec!["letter", "number"],
         svec!["a", "13"],
@@ -10,7 +10,7 @@ fn enumerate() {
         svec!["c", "72"],
         svec!["d", "7"],
     ]);
-    let mut cmd = wrk.command("enumerate");
+    let mut cmd = wrk.command("enum");
     cmd.arg("data.csv");
 
     let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
@@ -26,7 +26,7 @@ fn enumerate() {
 
 #[test]
 fn enumerate_column_name() {
-    let wrk = Workdir::new("enumerate");
+    let wrk = Workdir::new("enum");
     wrk.create("data.csv", vec![
         svec!["letter", "number"],
         svec!["a", "13"],
@@ -34,7 +34,7 @@ fn enumerate_column_name() {
         svec!["c", "72"],
         svec!["d", "7"],
     ]);
-    let mut cmd = wrk.command("enumerate");
+    let mut cmd = wrk.command("enum");
     cmd.arg("-c").arg("row").arg("data.csv");
 
     let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
@@ -50,7 +50,7 @@ fn enumerate_column_name() {
 
 #[test]
 fn enumerate_constant() {
-    let wrk = Workdir::new("enumerate");
+    let wrk = Workdir::new("enum");
     wrk.create("data.csv", vec![
         svec!["letter", "number"],
         svec!["a", "13"],
@@ -58,7 +58,7 @@ fn enumerate_constant() {
         svec!["c", "72"],
         svec!["d", "7"],
     ]);
-    let mut cmd = wrk.command("enumerate");
+    let mut cmd = wrk.command("enum");
     cmd.arg("--constant").arg("test").arg("data.csv");
 
     let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
@@ -74,7 +74,7 @@ fn enumerate_constant() {
 
 #[test]
 fn enumerate_copy() {
-    let wrk = Workdir::new("enumerate");
+    let wrk = Workdir::new("enum");
     wrk.create("data.csv", vec![
         svec!["letter", "number"],
         svec!["a", "13"],
@@ -82,7 +82,7 @@ fn enumerate_copy() {
         svec!["c", "72"],
         svec!["d", "7"],
     ]);
-    let mut cmd = wrk.command("enumerate");
+    let mut cmd = wrk.command("enum");
     cmd.arg("--copy").arg("number").arg("data.csv");
 
     let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
@@ -98,7 +98,7 @@ fn enumerate_copy() {
 
 #[test]
 fn enumerate_copy_name() {
-    let wrk = Workdir::new("enumerate");
+    let wrk = Workdir::new("enum");
     wrk.create("data.csv", vec![
         svec!["letter", "number"],
         svec!["a", "13"],
@@ -106,7 +106,7 @@ fn enumerate_copy_name() {
         svec!["c", "72"],
         svec!["d", "7"],
     ]);
-    let mut cmd = wrk.command("enumerate");
+    let mut cmd = wrk.command("enum");
     cmd.arg("--copy").arg("number").arg("-c").arg("chiffre").arg("data.csv");
 
     let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);

--- a/tests/test_enumerate.rs
+++ b/tests/test_enumerate.rs
@@ -35,7 +35,7 @@ fn enumerate_column_name() {
         svec!["d", "7"],
     ]);
     let mut cmd = wrk.command("enumerate");
-    cmd.arg("--column-name").arg("row").arg("data.csv");
+    cmd.arg("-c").arg("row").arg("data.csv");
 
     let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
     let expected = vec![

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -35,6 +35,7 @@ mod workdir;
 
 mod test_cat;
 mod test_count;
+mod test_enumerate;
 mod test_fixlengths;
 mod test_flatten;
 mod test_fmt;


### PR DESCRIPTION
Hello @BurntSushi,

A pull request adding an `enumerate` command to xsv. This command adds a new column to a CSV file and fills it with an incremental identifier or a uuid v4. This can be useful when needing to track sort orders across operations or if you need to keep a unique identifier for each line for whatever reason.

Have a good day,