### PR TITLE
Adding the `xsv apply` command

### DIFF
--- a/src/cmd/apply.rs
+++ b/src/cmd/apply.rs
@@ -1,0 +1,168 @@
+use csv;
+use regex::Regex;
+
+use CliResult;
+use config::{Delimiter, Config};
+use select::SelectColumns;
+use util;
+
+static USAGE: &'static str = "
+Apply a series of unary functions to a given CSV column. This can be used to
+perform typical cleaning tasks and/or harmonize some values etc.
+
+The series of operations must be given separated by commas as such:
+
+  trim => Trimming the cell
+  trim,upper => Trimming the cell then transforming to uppercase
+  '' => No-op
+
+Currently supported operations:
+
+  * len: Return string length
+  * lower: Transform to lowercase
+  * upper: Transform to uppercase
+  * squeeze: Compress consecutive whitespaces
+  * trim: Trim (drop whitespace left & right of the string)
+  * ltrim: Left trim
+  * rtrim: Right trim
+
+Example for trimming and transforming to uppercase:
+
+  $ xsv apply trim,upper surname -r uppercase_clean_surname file.csv
+
+You can also use this command to make a copy of a column:
+
+  $ xsv apply '' col -c col_copy file.csv
+
+Usage:
+    xsv apply [options] <operations> <column> [<input>]
+    xsv apply --help
+
+apply options:
+    -c, --new-column <name>  Put the transformed values in a new column instead.
+    -r, --rename <name>      New name for the transformed column.
+
+Common options:
+    -h, --help               Display this message
+    -o, --output <file>      Write output to <file> instead of stdout.
+    -n, --no-headers         When set, the first row will not be interpreted
+                             as headers.
+    -d, --delimiter <arg>    The field delimiter for reading CSV data.
+                             Must be a single character. (default: ,)
+";
+
+static OPERATIONS: &'static [&'static str] = &[
+    "len",
+    "lower",
+    "upper",
+    "squeeze",
+    "trim",
+    "rtrim",
+    "ltrim"
+];
+
+#[derive(Deserialize)]
+struct Args {
+    arg_column: SelectColumns,
+    arg_operations: String,
+    arg_input: Option<String>,
+    flag_rename: Option<String>,
+    flag_new_column: Option<String>,
+    flag_output: Option<String>,
+    flag_no_headers: bool,
+    flag_delimiter: Option<Delimiter>,
+}
+
+pub fn replace_column_value(record: &csv::ByteRecord, column_index: usize, new_value: &[u8])
+                           -> csv::ByteRecord {
+    record
+        .into_iter()
+        .enumerate()
+        .map(|(i, v)| if i == column_index { new_value } else { v })
+        .collect()
+}
+
+pub fn run(argv: &[&str]) -> CliResult<()> {
+    let args: Args = util::get_args(USAGE, argv)?;
+    let rconfig = Config::new(&args.arg_input)
+        .delimiter(args.flag_delimiter)
+        .no_headers(args.flag_no_headers)
+        .select(args.arg_column);
+
+    let mut rdr = rconfig.reader()?;
+    let mut wtr = Config::new(&args.flag_output).writer()?;
+
+    let mut headers = rdr.byte_headers()?.clone();
+    let sel = rconfig.selection(&headers)?;
+    let column_index = *sel.iter().next().unwrap();
+
+    let operations: Vec<&str> = args.arg_operations.split(",").collect();
+
+    for op in &operations {
+        if !OPERATIONS.contains(&op) {
+            return fail!(format!("Unknown \"{}\" operations found in \"{}\"", op, operations.join(",")));
+        }
+    }
+
+    if let Some(new_name) = args.flag_rename {
+        headers = replace_column_value(&headers, column_index, new_name.as_bytes());
+    }
+
+    if !rconfig.no_headers {
+
+        if let Some(new_column) = &args.flag_new_column {
+            headers.push_field(new_column.as_bytes());
+        }
+
+        wtr.write_record(&headers)?;
+    }
+
+    let squeezer = Regex::new(r"\s+")?;
+
+    let mut record = csv::ByteRecord::new();
+
+    while rdr.read_byte_record(&mut record)? {
+        let mut cell = String::from_utf8(record[column_index].to_vec())
+            .expect("Could not parse cell as utf-8!");
+
+        for op in &operations {
+            match op.as_ref() {
+                "len" => {
+                    cell = cell.len().to_string();
+                },
+                "lower" => {
+                    cell = cell.to_lowercase();
+                },
+                "upper" => {
+                    cell = cell.to_uppercase();
+                },
+                "squeeze" => {
+                    cell = squeezer.replace_all(&cell, " ").to_string();
+                },
+                "trim" => {
+                    cell = String::from(cell.trim());
+                },
+                "ltrim" => {
+                    cell = String::from(cell.trim_start());
+                },
+                "rtrim" => {
+                    cell = String::from(cell.trim_end());
+                },
+                _ => {}
+            }
+        }
+
+        match &args.flag_new_column {
+            Some(_) => {
+                record.push_field(cell.as_bytes());
+            }
+            None => {
+                record = replace_column_value(&record, column_index, cell.as_bytes());
+            }
+        }
+
+        wtr.write_byte_record(&record)?;
+    }
+
+    Ok(wtr.flush()?)
+}

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -1,3 +1,4 @@
+pub mod apply;
 pub mod cat;
 pub mod count;
 pub mod fixlengths;

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,6 +43,7 @@ macro_rules! fail {
 macro_rules! command_list {
     () => (
 "
+    apply       Apply series of transformations to a column
     cat         Concatenate by row or column
     count       Count records
     fixlengths  Makes all records have same length
@@ -140,6 +141,7 @@ Please choose one of the following commands:",
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "lowercase")]
 enum Command {
+    Apply,
     Cat,
     Count,
     FixLengths,
@@ -171,10 +173,11 @@ impl Command {
 
         if !argv[1].chars().all(char::is_lowercase) {
             return Err(CliError::Other(format!(
-                "xsv expects commands in lowercase. Did you mean '{}'?", 
+                "xsv expects commands in lowercase. Did you mean '{}'?",
                 argv[1].to_lowercase()).to_string()));
         }
         match self {
+            Command::Apply => cmd::apply::run(argv),
             Command::Cat => cmd::cat::run(argv),
             Command::Count => cmd::count::run(argv),
             Command::FixLengths => cmd::fixlengths::run(argv),

--- a/tests/test_apply.rs
+++ b/tests/test_apply.rs
@@ -1,0 +1,119 @@
+use workdir::Workdir;
+
+#[test]
+fn apply() {
+    let wrk = Workdir::new("apply");
+    wrk.create("data.csv", vec![
+        svec!["name"],
+        svec!["John"],
+        svec!["Mary"],
+        svec!["Sue"],
+        svec!["Hopkins"],
+    ]);
+    let mut cmd = wrk.command("apply");
+    cmd.arg("upper").arg("name").arg("data.csv");
+
+    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let expected = vec![
+        svec!["name"],
+        svec!["JOHN"],
+        svec!["MARY"],
+        svec!["SUE"],
+        svec!["HOPKINS"],
+    ];
+    assert_eq!(got, expected);
+}
+
+#[test]
+fn apply_chain() {
+    let wrk = Workdir::new("apply");
+    wrk.create("data.csv", vec![
+        svec!["name"],
+        svec!["John   "],
+        svec!["Mary"],
+        svec!["  Sue"],
+        svec!["Hopkins"],
+    ]);
+    let mut cmd = wrk.command("apply");
+    cmd.arg("trim,upper").arg("name").arg("data.csv");
+
+    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let expected = vec![
+        svec!["name"],
+        svec!["JOHN"],
+        svec!["MARY"],
+        svec!["SUE"],
+        svec!["HOPKINS"],
+    ];
+    assert_eq!(got, expected);
+}
+
+#[test]
+fn apply_no_headers() {
+    let wrk = Workdir::new("apply");
+    wrk.create("data.csv", vec![
+        svec!["John   "],
+        svec!["Mary"],
+        svec!["  Sue"],
+        svec!["Hopkins"],
+    ]);
+    let mut cmd = wrk.command("apply");
+    cmd.arg("trim,upper").arg("1").arg("--no-headers").arg("data.csv");
+
+    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let expected = vec![
+        svec!["JOHN"],
+        svec!["MARY"],
+        svec!["SUE"],
+        svec!["HOPKINS"],
+    ];
+    assert_eq!(got, expected);
+}
+
+#[test]
+fn apply_rename() {
+    let wrk = Workdir::new("apply");
+    wrk.create("data.csv", vec![
+        svec!["name"],
+        svec!["John"],
+        svec!["Mary"],
+        svec!["Sue"],
+        svec!["Hopkins"],
+    ]);
+    let mut cmd = wrk.command("apply");
+    cmd.arg("upper").arg("name").arg("--rename").arg("upper_name").arg("data.csv");
+
+    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let expected = vec![
+        svec!["upper_name"],
+        svec!["JOHN"],
+        svec!["MARY"],
+        svec!["SUE"],
+        svec!["HOPKINS"],
+    ];
+    assert_eq!(got, expected);
+}
+
+#[test]
+fn apply_new_column() {
+    let wrk = Workdir::new("apply");
+    wrk.create("data.csv", vec![
+        svec!["name"],
+        svec!["John"],
+        svec!["Mary"],
+        svec!["Sue"],
+        svec!["Hopkins"],
+    ]);
+    let mut cmd = wrk.command("apply");
+    cmd.arg("upper").arg("name").arg("--new-column").arg("upper_name").arg("data.csv");
+
+    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let expected = vec![
+        svec!["name", "upper_name"],
+        svec!["John", "JOHN"],
+        svec!["Mary", "MARY"],
+        svec!["Sue", "SUE"],
+        svec!["Hopkins", "HOPKINS"],
+    ];
+    assert_eq!(got, expected);
+}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -33,6 +33,7 @@ macro_rules! rassert_eq {
 
 mod workdir;
 
+mod test_apply;
 mod test_cat;
 mod test_count;
 mod test_fixlengths;


### PR DESCRIPTION
Hello @BurntSushi,

A PR adding a `xsv apply` command that can be used to apply a series of unary string transformation over the values of a given column.

The command can also be used to copy a column, which can be useful with some destructive operations such as `xsv replace`.

Have a good day,