### PR TITLE
docs: CSV Kit comparison is out-of-date

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,10 +103,6 @@ $ xsv stats worldcitiespop.csv --everything | xsv table
 Which cuts it down to about 8 seconds on my machine. (And creating the index
 takes less than 2 seconds.)
 
-Notably, the same type of "statistics" command in another
-[CSV command line toolkit](https://csvkit.readthedocs.io/)
-takes about 2 minutes to produce similar statistics on the same data set.
-
 Creating an index gives us more than just faster statistics gathering. It also
 makes slice operations extremely fast because *only the sliced portion* has to
 be parsed. For example, let's say you wanted to grab the last 10 records:


### PR DESCRIPTION
On my machine, xsv takes about 5 seconds and csvstat takes about 10 seconds (it was dramatically improved in the latest release). Instead of updating every number in the readme (10s on my machine is faster than whatever machine got xsv to run in 12s), I suggest removing the paragraph.