### PR TITLE
Chore: fix a description of count --no-headers option

### DIFF
--- a/src/cmd/count.rs
+++ b/src/cmd/count.rs
@@ -15,7 +15,7 @@ Usage:
 
 Common options:
     -h, --help             Display this message
-    -n, --no-headers       When set, the first row will not be included in
+    -n, --no-headers       When set, the first row will be included in
                            the count.
     -d, --delimiter <arg>  The field delimiter for reading CSV data.
                            Must be a single character. (default: ,)


### PR DESCRIPTION
related to https://github.com/BurntSushi/xsv/issues/329

just fix a description of count --no-headers option.

```
$ ./target/debug/xsv count --help
Prints a count of the number of records in the CSV data.

Note that the count will not include the header row (unless --no-headers is
given).

Usage:
    xsv count [options] [<input>]

Common options:
    -h, --help             Display this message
    -n, --no-headers       When set, the first row will be included in
                           the count.
    -d, --delimiter <arg>  The field delimiter for reading CSV data.
                           Must be a single character. (default: ,)
