### PR TITLE
docs(install): add x-cmd method to install xsv

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,6 +321,12 @@ If you're a **Nix/NixOS** user, you can install xsv from nixpkgs:
 $ nix-env -i xsv
 ```
 
+If you're a **[X-CMD](https://www.x-cmd.com)** user, you can install xsv from `x env` command:
+
+```
+$ x env use xsv
+```
+
 Alternatively, you can compile from source by
 [installing Cargo](https://crates.io/install)
 ([Rust's](https://www.rust-lang.org/) package manager)


### PR DESCRIPTION
- Hi, [x-cmd](https://x-cmd.com) is a lightweight cross-platform package manager implemented in posix shell. Quickly download and execute `xsv` with a single command: [`x xsv`](https://x-cmd.com/pkg/xsv)
- You can also install `xsv` in the user level without requiring root privileges.
  ```sh
  x env use xsv
  ```
- By the way, we wrote a [xsv introduction article and a demo](https://www.x-cmd.com/pkg/xsv)