### PR TITLE
Update ssh address in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,7 +333,7 @@ cargo install xsv
 Compiling from this repository also works similarly:
 
 ```bash
-git clone git://github.com/BurntSushi/xsv
+git clone git@github.com:BurntSushi/xsv.git 
 cd xsv
 cargo build --release
 ```


### PR DESCRIPTION
## What

Updated the code snippet.

## Why

The `git clone` instructions pointed to an outdated ssh address format. 

## Concerns

None, only a README change.